### PR TITLE
Handle imports with multiple API round-trips

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,21 @@ RFC: https://github.com/wagtail/rfcs/pull/42
 
   into the urlpatterns list, above the `include(wagtail_urls)` line.
 
-* Add a `WAGTAILTRANSFER_SOURCES` setting to your project settings. This is a dict defining the sites available to import from, for example:
+* Add the settings `WAGTAILTRANSFER_SOURCES` and `WAGTAILTRANSFER_SECRET_KEY` to your project settings. For example:
 
       WAGTAILTRANSFER_SOURCES = {
           'staging': {
               'BASE_URL': 'https://staging.example.com/wagtail-transfer/',
+              'SECRET_KEY': '4ac4822149691395773b2a8942e1a472',
           },
           'production': {
               'BASE_URL': 'https://www.example.com/wagtail-transfer/',
+              'SECRET_KEY': 'a36476ffc6af34dc935570d97369eca0',
           },
       }
+
+      WAGTAILTRANSFER_SECRET_KEY = '7cd5de8229be75e1e0c2af8abc2ada7e'
+
+  `WAGTAILTRANSFER_SOURCES` is a dict defining the sites available to import from.
+
+  `WAGTAILTRANSFER_SECRET_KEY` and the per-source `SECRET_KEY` settings are used to authenticate the communication between the source and destination instances; this prevents unauthorised users from using this API to retrieve sensitive data such as password hashes. The `SECRET_KEY` for each entry in `WAGTAILTRANSFER_SOURCES` must match that instance's `WAGTAILTRANSFER_SECRET_KEY`.

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ RFC: https://github.com/wagtail/rfcs/pull/42
 
       WAGTAILTRANSFER_SOURCES = {
           'staging': {
-              'CHOOSER_API': 'https://staging.example.com/wagtail-transfer/api/chooser/pages/',
+              'BASE_URL': 'https://staging.example.com/wagtail-transfer/',
           },
           'production': {
-              'CHOOSER_API': 'https://www.example.com/wagtail-transfer/api/chooser/pages/',
+              'BASE_URL': 'https://www.example.com/wagtail-transfer/',
           },
       }

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -134,5 +134,13 @@ BASE_URL = 'http://example.com'
 WAGTAILTRANSFER_SOURCES = {
     'staging': {
         'BASE_URL': 'https://www.example.com/wagtail-transfer/',
+        'SECRET_KEY': 'i-am-the-staging-example-secret-key',
+    },
+    'local': {
+        # so that we can use the wagtail_transfer.auth.digest_for_source helper in API tests
+        'BASE_URL': 'http://localhost/wagtail-transfer/',
+        'SECRET_KEY': 'i-am-the-local-secret-key',
     }
 }
+
+WAGTAILTRANSFER_SECRET_KEY = 'i-am-the-local-secret-key'

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -130,3 +130,9 @@ SECRET_KEY = 'not needed'
 
 WAGTAIL_SITE_NAME = "wagtail-transfer"
 BASE_URL = 'http://example.com'
+
+WAGTAILTRANSFER_SOURCES = {
+    'staging': {
+        'BASE_URL': 'https://www.example.com/wagtail-transfer/',
+    }
+}

--- a/tests/tests/test_api.py
+++ b/tests/tests/test_api.py
@@ -91,6 +91,26 @@ class TestPagesApi(TestCase):
         self.assertIn(['wagtailcore.page', 1, '11111111-1111-1111-1111-111111111111'], data['mappings'])
 
 
+class TestObjectsApi(TestCase):
+    fixtures = ['test.json']
+
+    def test_objects_api(self):
+        request_data = {
+            'tests.advert': [1]
+        }
+        response = self.client.post(
+            '/wagtail-transfer/api/objects/', json.dumps(request_data), content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+
+        self.assertEqual(data['ids_for_import'], [])
+        self.assertEqual(data['objects'][0]['model'], 'tests.advert')
+        self.assertEqual(data['objects'][0]['fields']['slogan'], "put a tiger in your tank")
+
+        self.assertEqual(data['mappings'], [['tests.advert', 1, 'adadadad-1111-1111-1111-111111111111']])
+
+
 @override_settings(
     WAGTAILTRANSFER_SOURCES={
         'staging': {

--- a/tests/tests/test_api.py
+++ b/tests/tests/test_api.py
@@ -92,9 +92,9 @@ class TestPagesApi(TestCase):
 
 
 @override_settings(
-    WAGTAILTRANSFER_SOURCES = {
+    WAGTAILTRANSFER_SOURCES={
         'staging': {
-            'CHOOSER_API': 'https://www.example.com/api/chooser/',
+            'BASE_URL': 'https://www.example.com/wagtail-transfer/',
         }
     }
 )
@@ -111,7 +111,7 @@ class TestChooserProxyApi(TestCase):
 
         response = self.client.get('/admin/wagtail-transfer/api/chooser-proxy/staging/foo?bar=baz', HTTP_ACCEPT='application/json')
 
-        get.assert_called_once_with('https://www.example.com/api/chooser/foo?bar=baz', headers={'Accept': 'application/json'}, timeout=5)
+        get.assert_called_once_with('https://www.example.com/wagtail-transfer/api/chooser/pages/foo?bar=baz', headers={'Accept': 'application/json'}, timeout=5)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, b'test content')

--- a/tests/tests/test_api.py
+++ b/tests/tests/test_api.py
@@ -1,7 +1,7 @@
 import json
 from unittest import mock
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from wagtail.core.models import Page
 
 from tests.models import PageWithRichText, SectionedPage
@@ -111,13 +111,6 @@ class TestObjectsApi(TestCase):
         self.assertEqual(data['mappings'], [['tests.advert', 1, 'adadadad-1111-1111-1111-111111111111']])
 
 
-@override_settings(
-    WAGTAILTRANSFER_SOURCES={
-        'staging': {
-            'BASE_URL': 'https://www.example.com/wagtail-transfer/',
-        }
-    }
-)
 @mock.patch('requests.get')
 class TestChooserProxyApi(TestCase):
     fixtures = ['test.json']

--- a/tests/tests/test_views.py
+++ b/tests/tests/test_views.py
@@ -1,0 +1,135 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from wagtail_transfer.operations import ImportPlanner
+from tests.models import PageWithRichText, SectionedPage, SimplePage, SponsoredPage
+
+
+class TestChooseView(TestCase):
+    fixtures = ['test.json']
+
+    def setUp(self):
+        self.client.login(username='admin', password='password')
+
+    def test_get(self):
+        response = self.client.get('/admin/wagtail-transfer/choose/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'data-wagtail-component="content-import-form"')
+
+
+@mock.patch('requests.post')
+@mock.patch('requests.get')
+class TestImportView(TestCase):
+    fixtures = ['test.json']
+
+    def setUp(self):
+        self.client.login(username='admin', password='password')
+
+    def test_run(self, get, post):
+        get.return_value.status_code = 200
+        get.return_value.content = b"""{
+            "ids_for_import": [
+                ["wagtailcore.page", 12],
+                ["wagtailcore.page", 15],
+                ["wagtailcore.page", 16]
+            ],
+            "mappings": [
+                ["wagtailcore.page", 12, "22222222-2222-2222-2222-222222222222"],
+                ["wagtailcore.page", 15, "00017017-5555-5555-5555-555555555555"],
+                ["wagtailcore.page", 16, "00e99e99-6666-6666-6666-666666666666"],
+                ["tests.advert", 11, "adadadad-1111-1111-1111-111111111111"],
+                ["tests.advert", 8, "adadadad-8888-8888-8888-888888888888"]
+            ],
+            "objects": [
+                {
+                    "model": "tests.simplepage",
+                    "pk": 12,
+                    "parent_id": 1,
+                    "fields": {
+                        "title": "Home",
+                        "show_in_menus": false,
+                        "live": true,
+                        "slug": "home",
+                        "intro": "This is the updated homepage"
+                    }
+                },
+                {
+                    "model": "tests.sponsoredpage",
+                    "pk": 15,
+                    "parent_id": 12,
+                    "fields": {
+                        "title": "Oil is still great",
+                        "show_in_menus": false,
+                        "live": true,
+                        "slug": "oil-is-still-great",
+                        "advert": 11,
+                        "intro": "yay fossil fuels and climate change"
+                    }
+                },
+                {
+                    "model": "tests.sponsoredpage",
+                    "pk": 16,
+                    "parent_id": 12,
+                    "fields": {
+                        "title": "Eggs are great too",
+                        "show_in_menus": false,
+                        "live": true,
+                        "slug": "eggs-are-great-too",
+                        "advert": 8,
+                        "intro": "you can make cakes with them"
+                    }
+                }
+            ]
+        }"""
+
+        post.return_value.status_code = 200
+        post.return_value.content = """{
+            "ids_for_import": [
+            ],
+            "mappings": [
+                ["tests.advert", 11, "adadadad-1111-1111-1111-111111111111"],
+                ["tests.advert", 8, "adadadad-8888-8888-8888-888888888888"]
+            ],
+            "objects": [
+                {
+                    "model": "tests.advert",
+                    "pk": 11,
+                    "fields": {
+                        "slogan": "put a leopard in your tank"
+                    }
+                },
+                {
+                    "model": "tests.advert",
+                    "pk": 8,
+                    "fields": {
+                        "slogan": "go to work on an egg"
+                    }
+                }
+            ]
+        }"""
+
+        response = self.client.post('/admin/wagtail-transfer/import/', {
+            'source': 'staging',
+            'source_page_id': '12',
+            'dest_page_id': '2',
+        })
+
+        # Pages API should be called once, with 12 as the root page
+        get.assert_called_once_with('https://www.example.com/wagtail-transfer/api/pages/12/')
+
+        # then the Objects API should be called, requesting adverts with ID 11 and 8
+        post.assert_called_once()
+        args, kwargs = post.call_args
+        self.assertEqual(args[0], 'https://www.example.com/wagtail-transfer/api/objects/')
+        requested_ids = kwargs['json']['tests.advert']
+        self.assertEqual(set(requested_ids), set([8, 11]))
+
+        # Check import results
+        updated_page = SponsoredPage.objects.get(url_path='/home/oil-is-still-great/')
+        self.assertEqual(updated_page.intro, "yay fossil fuels and climate change")
+        self.assertEqual(updated_page.advert.slogan, "put a leopard in your tank")
+
+        created_page = SponsoredPage.objects.get(url_path='/home/eggs-are-great-too/')
+        self.assertEqual(created_page.intro, "you can make cakes with them")
+        self.assertEqual(created_page.advert.slogan, "go to work on an egg")

--- a/wagtail_transfer/auth.py
+++ b/wagtail_transfer/auth.py
@@ -1,0 +1,33 @@
+import hashlib
+import hmac
+
+from django.conf import settings
+from django.core.exceptions import PermissionDenied
+
+
+def check_digest(message, digest):
+    key = settings.WAGTAILTRANSFER_SECRET_KEY
+
+    # Key and message must be bytes objects
+    if isinstance(key, str):
+        key = key.encode()
+
+    if isinstance(message, str):
+        message = message.encode()
+
+    expected_digest = hmac.new(key, message, hashlib.sha1).hexdigest()
+    if not hmac.compare_digest(digest, expected_digest):
+        raise PermissionDenied
+
+
+def digest_for_source(source, message):
+    key = settings.WAGTAILTRANSFER_SOURCES[source]['SECRET_KEY']
+
+    # Key and message must be bytes objects
+    if isinstance(key, str):
+        key = key.encode()
+
+    if isinstance(message, str):
+        message = message.encode()
+
+    return hmac.new(key, message, hashlib.sha1).hexdigest()

--- a/wagtail_transfer/models.py
+++ b/wagtail_transfer/models.py
@@ -21,3 +21,19 @@ def get_base_model(model):
     if model._meta.parents:
         model = model._meta.get_parent_list()[0]
     return model
+
+
+def get_model_for_path(model_path):
+    """
+    Given an 'app_name.model_name' string, return the model class
+    """
+    app_label, model_name = model_path.split('.')
+    return ContentType.objects.get_by_natural_key(app_label, model_name).model_class()
+
+
+def get_base_model_for_path(model_path):
+    """
+    Given an 'app_name.model_name' string, return the Model class for the base model
+    (e.g. for 'blog.blog_page', return Page)
+    """
+    return get_base_model(get_model_for_path(model_path))

--- a/wagtail_transfer/operations.py
+++ b/wagtail_transfer/operations.py
@@ -9,7 +9,7 @@ from wagtail.core.fields import RichTextField
 from wagtail.core.models import Page
 
 from .richtext import get_reference_handler
-from .models import get_base_model, IDMapping
+from .models import get_base_model, get_base_model_for_path, get_model_for_path, IDMapping
 
 
 class ImportPlanner:
@@ -76,20 +76,6 @@ class ImportPlanner:
         # Mapping from tasks to operations that perform the task
         self.task_resolutions = {}
 
-    def _model_for_path(self, model_path):
-        """
-        Given an 'app_name.model_name' string, return the model class
-        """
-        app_label, model_name = model_path.split('.')
-        return ContentType.objects.get_by_natural_key(app_label, model_name).model_class()
-
-    def _base_model_for_path(self, model_path):
-        """
-        Given an 'app_name.model_name' string, return the Model class for the base model
-        (e.g. for 'blog.blog_page', return Page)
-        """
-        return get_base_model(self._model_for_path(model_path))
-
     def add_json(self, json_data):
         """
         Add JSON data to the import plan. The data is a dict consisting of:
@@ -111,7 +97,7 @@ class ImportPlanner:
 
         # add source id -> uid mappings to the uids_by_source dict
         for model_path, source_id, uid in data['mappings']:
-            model = self._base_model_for_path(model_path)
+            model = get_base_model_for_path(model_path)
             self.uids_by_source[(model, source_id)] = uid
 
         # add object data to the object_data_by_source dict
@@ -124,7 +110,7 @@ class ImportPlanner:
         # for each ID in the import list, add an objective to specify that we want an up-to-date
         # copy of that object on the destination site
         for model_path, source_id in data['ids_for_import']:
-            model = self._base_model_for_path(model_path)
+            model = get_base_model_for_path(model_path)
             objective = (model, source_id, 'updated')
 
             # add to the set of objectives that need handling
@@ -137,7 +123,7 @@ class ImportPlanner:
             self._handle_objective(objective)
 
     def _add_object_data_to_lookup(self, obj_data):
-        model = self._base_model_for_path(obj_data['model'])
+        model = get_base_model_for_path(obj_data['model'])
         source_id = obj_data['pk']
         self.object_data_by_source[(model, source_id)] = obj_data
 
@@ -222,7 +208,7 @@ class ImportPlanner:
             return
 
         # retrieve the specific model for this object
-        specific_model = self._model_for_path(object_data['model'])
+        specific_model = get_model_for_path(object_data['model'])
 
         if issubclass(specific_model, Page):
             if action == 'create':

--- a/wagtail_transfer/serializers.py
+++ b/wagtail_transfer/serializers.py
@@ -40,6 +40,13 @@ class ModelSerializer:
 
             self.field_adapters.append(get_field_adapter(field))
 
+    def get_objects_by_ids(self, ids):
+        """
+        Given a list of IDs, return a queryset of model instances that we can
+        run serialize and get_object_references on
+        """
+        return self.model.objects.filter(pk__in=ids)
+
     def serialize_fields(self, instance):
         return {
             field_adapter.name: field_adapter.serialize(instance)
@@ -69,6 +76,10 @@ class PageSerializer(ModelSerializer):
         'go_live_at', 'expire_at', 'expired', 'locked', 'first_published_at', 'last_published_at',
         'latest_revision_created_at', 'live_revision',
     ]
+
+    def get_objects_by_ids(self, ids):
+        # serialize method needs the instance in its specific form
+        return super().get_objects_by_ids(ids).specific()
 
     def serialize(self, instance):
         result = super().serialize(instance)

--- a/wagtail_transfer/urls.py
+++ b/wagtail_transfer/urls.py
@@ -9,5 +9,6 @@ chooser_api.register_endpoint('pages', views.PageChooserAPIViewSet)
 
 urlpatterns = [
     url(r'^api/pages/(\d+)/$', views.pages_for_export, name='wagtail_transfer_pages'),
+    url(r'^api/objects/$', views.objects_for_export, name='wagtail_transfer_objects'),
     url(r'^api/chooser/', chooser_api.urls),
 ]

--- a/wagtail_transfer/views.py
+++ b/wagtail_transfer/views.py
@@ -64,7 +64,9 @@ def chooser_api_proxy(request, source_name, path):
     if source_config is None:
         raise Http404("Source does not exist")
 
-    response = requests.get(f"{source_config['CHOOSER_API']}{path}?{request.GET.urlencode()}", headers={
+    base_url = source_config['BASE_URL'] + 'api/chooser/pages/'
+
+    response = requests.get(f"{base_url}{path}?{request.GET.urlencode()}", headers={
         'Accept': request.META['HTTP_ACCEPT'],
     }, timeout=5)
 
@@ -86,7 +88,8 @@ def choose_page(request):
 
 @require_POST
 def do_import(request):
-    response = requests.get(f"http://localhost:8000/wagtail-transfer/api/pages/{request.POST['source_page_id']}/")
+    source_config = settings.WAGTAILTRANSFER_SOURCES[request.POST['source']]
+    response = requests.get(f"{source_config['BASE_URL']}api/pages/{request.POST['source_page_id']}/")
 
     importer = ImportPlanner(request.POST['source_page_id'], request.POST['dest_page_id'])
     importer.add_json(response.content)


### PR DESCRIPTION
Implement an 'objects' API that the importing side can use to request related objects that were not part of the initial dataset returned by the 'pages' API, and update the import view to make as many requests to it as necessary to resolve all objects.