### PR TITLE
Rebase #9 / fix handling of root collection

### DIFF
--- a/tests/tests/test_import.py
+++ b/tests/tests/test_import.py
@@ -308,26 +308,26 @@ class TestImport(TestCase):
         data = """{
                 "ids_for_import": [
                     ["wagtailcore.page", 6]
-                ], 
+                ],
                 "mappings": [
-                    ["wagtailcore.page", 6, "0c7a9390-16cb-11ea-8000-0800278dc04d"], 
-                    ["wagtailcore.page", 300, "33333333-3333-3333-3333-333333333333"], 
-                    ["wagtailcore.page", 200, "22222222-2222-2222-2222-222222222222"], 
-                    ["wagtailcore.page", 500, "00017017-5555-5555-5555-555555555555"], 
+                    ["wagtailcore.page", 6, "0c7a9390-16cb-11ea-8000-0800278dc04d"],
+                    ["wagtailcore.page", 300, "33333333-3333-3333-3333-333333333333"],
+                    ["wagtailcore.page", 200, "22222222-2222-2222-2222-222222222222"],
+                    ["wagtailcore.page", 500, "00017017-5555-5555-5555-555555555555"],
                     ["wagtailcore.page", 100, "11111111-1111-1111-1111-111111111111"]
-                ], 
+                ],
                 "objects": [
                     {
-                        "model": "tests.pagewithstreamfield", 
-                        "pk": 6, 
+                        "model": "tests.pagewithstreamfield",
+                        "pk": 6,
                         "fields": {
-                            "title": "I have a streamfield", 
-                            "slug": "i-have-a-streamfield", 
-                            "live": true, 
-                            "seo_title": "", 
-                            "show_in_menus": false, 
-                            "search_description": "", 
-                            "body": "[{\\"type\\": \\"link_block\\", \\"value\\": {\\"page\\": 100, \\"text\\": \\"Test\\"}, \\"id\\": \\"fc3b0d3d-d316-4271-9e31-84919558188a\\"}, {\\"type\\": \\"page\\", \\"value\\": 200, \\"id\\": \\"c6d07d3a-72d4-445e-8fa5-b34107291176\\"}, {\\"type\\": \\"stream\\", \\"value\\": [{\\"type\\": \\"page\\", \\"value\\": 300, \\"id\\": \\"8c0d7de7-4f77-4477-be67-7d990d0bfb82\\"}], \\"id\\": \\"21ffe52a-c0fc-4ecc-92f1-17b356c9cc94\\"}, {\\"type\\": \\"list_of_pages\\", \\"value\\": [500], \\"id\\": \\"17b972cb-a952-4940-87e2-e4eb00703997\\"}]"}, 
+                            "title": "I have a streamfield",
+                            "slug": "i-have-a-streamfield",
+                            "live": true,
+                            "seo_title": "",
+                            "show_in_menus": false,
+                            "search_description": "",
+                            "body": "[{\\"type\\": \\"link_block\\", \\"value\\": {\\"page\\": 100, \\"text\\": \\"Test\\"}, \\"id\\": \\"fc3b0d3d-d316-4271-9e31-84919558188a\\"}, {\\"type\\": \\"page\\", \\"value\\": 200, \\"id\\": \\"c6d07d3a-72d4-445e-8fa5-b34107291176\\"}, {\\"type\\": \\"stream\\", \\"value\\": [{\\"type\\": \\"page\\", \\"value\\": 300, \\"id\\": \\"8c0d7de7-4f77-4477-be67-7d990d0bfb82\\"}], \\"id\\": \\"21ffe52a-c0fc-4ecc-92f1-17b356c9cc94\\"}, {\\"type\\": \\"list_of_pages\\", \\"value\\": [500], \\"id\\": \\"17b972cb-a952-4940-87e2-e4eb00703997\\"}]"},
                             "parent_id": 300
                         }
                     ]

--- a/tests/tests/test_import.py
+++ b/tests/tests/test_import.py
@@ -383,11 +383,9 @@ class TestImport(TestCase):
                     "model": "wagtailcore.collection",
                     "pk": 3,
                     "fields": {
-                        "path": "0001",
-                        "depth": 1,
-                        "numchild": 0,
                         "name": "Root"
-                    }
+                    },
+                    "parent_id": null
                 },
                 {
                     "model": "wagtailimages.image",
@@ -454,9 +452,6 @@ class TestImport(TestCase):
                     "model": "wagtailcore.collection",
                     "pk": 4,
                     "fields": {
-                        "path": "00010001",
-                        "depth": 2,
-                        "numchild": 0,
                         "name": "New collection"
                     },
                     "parent_id": """ + str(root_collection.id) + """

--- a/wagtail_transfer/operations.py
+++ b/wagtail_transfer/operations.py
@@ -10,6 +10,7 @@ from django.core.files.base import ContentFile
 from django.utils.functional import cached_property
 from modelcluster.models import ClusterableModel, get_all_child_relations
 import requests
+from treebeard.mp_tree import MP_Node
 from taggit.managers import TaggableManager
 from wagtail.core.fields import RichTextField, StreamField
 from wagtail.core.models import Page
@@ -249,7 +250,6 @@ class ImportPlanner:
         except KeyError:
             pass
 
-        # TODO: Refactor this so it looks nicer
         if task[0] == 'transfer-file':
             operation = TransferFile(task[1])
         else:
@@ -265,20 +265,20 @@ class ImportPlanner:
             # retrieve the specific model for this object
             specific_model = get_model_for_path(object_data['model'])
 
-            if issubclass(specific_model, Page):
+            if issubclass(specific_model, MP_Node):
                 if action == 'create':
-                    if source_id == self.root_page_source_pk:
+                    if issubclass(specific_model, Page) and source_id == self.root_page_source_pk:
                         # this is the root page of the import; ignore the parent ID in the source
                         # record and import at the requested destination instead
-                        operation = CreatePage(specific_model, object_data, self.destination_parent_id)
+                        operation = CreateTreeModel(specific_model, object_data, self.destination_parent_id)
                     else:
-                        operation = CreatePage(specific_model, object_data)
+                        operation = CreateTreeModel(specific_model, object_data)
                 else:  # action == 'update'
                     destination_id = self.destination_ids_by_source[(model, source_id)]
                     obj = specific_model.objects.get(pk=destination_id)
-                    operation = UpdatePage(obj, object_data)
+                    operation = UpdateModel(obj, object_data)
             else:
-                # non-page model
+                # non-tree model
                 if action == 'create':
                     operation = CreateModel(specific_model, object_data)
                 else:  # action == 'update'
@@ -530,7 +530,12 @@ class CreateModel(SaveOperationMixin, Operation):
         context.destination_ids_by_source[(self.base_model, source_pk)] = self.instance.pk
 
 
-class CreatePage(CreateModel):
+class CreateTreeModel(CreateModel):
+    """
+    Create an instance of a model that is structured in a Treebeard tree
+
+    For example: Pages and Collections
+    """
     def __init__(self, model, object_data, destination_parent_id=None):
         super().__init__(model, object_data)
         self.destination_parent_id = destination_parent_id
@@ -541,7 +546,7 @@ class CreatePage(CreateModel):
         if self.destination_parent_id is None:
             # need to ensure parent page is imported before this one
             deps.append(
-                ('exists', Page, self.object_data['parent_id']),
+                ('exists', get_base_model(self.model), self.object_data['parent_id']),
             )
 
         return deps
@@ -551,12 +556,12 @@ class CreatePage(CreateModel):
             # The destination parent ID was not known at the time this operation was built,
             # but should now exist in the page ID mapping
             source_parent_id = self.object_data['parent_id']
-            self.destination_parent_id = context.destination_ids_by_source[(Page, source_parent_id)]
+            self.destination_parent_id = context.destination_ids_by_source[(get_base_model(self.model), source_parent_id)]
 
-        parent_page = Page.objects.get(id=self.destination_parent_id)
+        parent = get_base_model(self.model).objects.get(id=self.destination_parent_id)
 
-        # Add the page to the database as a child of parent_page
-        parent_page.add_child(instance=self.instance)
+        # Add the page to the database as a child of parent
+        parent.add_child(instance=self.instance)
 
 
 class UpdateModel(SaveOperationMixin, Operation):
@@ -568,10 +573,6 @@ class UpdateModel(SaveOperationMixin, Operation):
     def run(self, context):
         self._populate_fields(context)
         self._save(context)
-
-
-class UpdatePage(UpdateModel):
-    pass
 
 
 class DeleteModel(Operation):


### PR DESCRIPTION
Rebase of #9, with additional fix so that it doesn't require an IDMapping to exist for the root collection (https://github.com/wagtail/wagtail-transfer/pull/9#discussion_r355687499) - instead, whenever we handle a 'create' task for a node with parent_id=None, we resolve it to the existing root node.

@jacobtoppm - only the last two commits need reviewing.