### PR TITLE
Handle FileFields with non-callable upload_to properties

### DIFF
--- a/wagtail_transfer/field_adapters.py
+++ b/wagtail_transfer/field_adapters.py
@@ -181,7 +181,7 @@ class FileAdapter(FieldAdapter):
 
             # Get the local filename
             name = pathlib.PurePosixPath(urlparse(value['download_url']).path).name
-            local_filename = self.field.upload_to(instance, name)
+            local_filename = self.field.generate_filename(instance, name)
 
             _file = File(local_filename, value['size'], value['hash'], value['download_url'])
             imported_file = _file.transfer()


### PR DESCRIPTION
The current FileField handler attempts to generate a local filename by calling upload_to as a function, which works for Wagtail's own Image and Document models (which set upload_to to a callable) but not the general case where it can be a string or None. FileField provides an internal generate_filename method which handles all cases - use this instead.