### PR TITLE
Check for value / return empty set

### DIFF
--- a/wagtail_transfer/streamfield.py
+++ b/wagtail_transfer/streamfield.py
@@ -104,7 +104,9 @@ class RichTextBlockHandler(BaseBlockHandler):
 
 class ChooserBlockHandler(BaseBlockHandler):
     def get_object_references(self, value):
-        return {(self.block.target_model, value)}
+        if value:
+            return {(self.block.target_model, value)}
+        return set()
 
     def update_ids(self, value, destination_ids_by_source):
         value = destination_ids_by_source.get((self.block.target_model, value), value)


### PR DESCRIPTION
When a Chooser can be null in a block it will throw an IntegrityError (`NOT NULL constraint failed: wagtail_transfer_idmapping.local_id`) 

This fixes that issue. 