### PR TITLE
Use absolute URL for images

### DIFF
--- a/wagtail_transfer/files.py
+++ b/wagtail_transfer/files.py
@@ -107,7 +107,7 @@ class File:
         response = requests.get(self.source_url)
 
         if response.status_code != 200:
-            raise FileTransferError  # TODO
+            raise FileTransferError("Non-200 response from image URL")
 
         return ImportedFile.objects.create(
             file=ContentFile(response.content, name=self.local_filename),


### PR DESCRIPTION
Made more use of the `FileTransferError` exception. 

Placed the BASE_URL in front of the `download_url` if the `MEDIA_URL` starts with a `/` as it's likely to be a relevant URL such as `/media/`. This lets wagtail-transfer download the images from an absolute URL every time. 