### PR TITLE
Look for embedtypes in RichText

### DIFF
--- a/wagtail_transfer/richtext.py
+++ b/wagtail_transfer/richtext.py
@@ -83,6 +83,6 @@ def get_reference_handler():
         link_handlers = features.get_link_types()
         REFERENCE_HANDLER = MultiTypeRichTextReferenceHandler([
             RichTextReferenceHandler(link_handlers, FIND_A_TAG, 'linktype'),
-            RichTextReferenceHandler(embed_handlers, FIND_EMBED_TAG, 'embed')
+            RichTextReferenceHandler(embed_handlers, FIND_EMBED_TAG, 'embedtype')
             ])
     return REFERENCE_HANDLER


### PR DESCRIPTION
Previously this was not importing images from source to destination. This fixes that issue and allows the destination site to pick up on the embed types in the RichText markup. 

@jacobtoppm actually solved this, I just opened the PR 🎉 