### PR TITLE
Nullable RichText fix

### DIFF
--- a/wagtail_transfer/richtext.py
+++ b/wagtail_transfer/richtext.py
@@ -39,20 +39,23 @@ class RichTextReferenceHandler:
     def get_objects(self, html):
         # Gets object references
         objects = set()
-        for match in self.tag_matcher.finditer(html):
-            attrs = extract_attrs(match.group(1))
-            try:
-                handler = self.handlers[attrs[self.type_attribute]]
-                objects.add((get_base_model(handler.get_model()), int(attrs['id'])))
-            except KeyError:
-                # If no handler can be found, no object reference can be added.
-                # This might occur when the link is a plain url
-                pass
+        if html:
+            for match in self.tag_matcher.finditer(html):
+                attrs = extract_attrs(match.group(1))
+                try:
+                    handler = self.handlers[attrs[self.type_attribute]]
+                    objects.add((get_base_model(handler.get_model()), int(attrs['id'])))
+                except KeyError:
+                    # If no handler can be found, no object reference can be added.
+                    # This might occur when the link is a plain url
+                    pass
         return objects
 
     def update_ids(self, html, destination_ids_by_source):
         # Update source instance ids to destination instance ids when possible
-        return self.tag_matcher.sub(partial(self.update_tag_id, destination_ids_by_source=destination_ids_by_source), html)
+        if html:
+            return self.tag_matcher.sub(partial(self.update_tag_id, destination_ids_by_source=destination_ids_by_source), html)
+        return ''
 
 
 class MultiTypeRichTextReferenceHandler:


### PR DESCRIPTION
Ran into a problem where:
```python
class MyPage(Page):
    fieldname = RichTextField(null=True, blank=True)
```
And thus the imports won't work with this field. The problem is `null=True` is acceptable even if it's not a Django best practice. 

So this fix just checks for a value from the `html` argument so there's always something to work with, as opposed to trying to operate with a NoneType 