### PR TITLE
Include parent IDs from tree models in mappings

### DIFF
--- a/wagtail_transfer/serializers.py
+++ b/wagtail_transfer/serializers.py
@@ -83,6 +83,14 @@ class TreeModelSerializer(ModelSerializer):
 
         return result
 
+    def get_object_references(self, instance):
+        refs = super().get_object_references(instance)
+        if not instance.is_root():
+            # add a reference for the parent ID
+            refs.add(
+                (self.base_model, instance.get_parent().pk)
+            )
+        return refs
 
 class PageSerializer(TreeModelSerializer):
     ignored_fields = TreeModelSerializer.ignored_fields + [


### PR DESCRIPTION
Fixes an error encountered when an import contains images that are all in non-root collections, and those collections are not found at the destination. Importing the Blog section of bakerydemo replicates this.

This happened because the API failed to include a mapping entry for the parent ID of a tree model (i.e. Page or Collection, although this is unlikely to come up for pages as the default `WAGTAILTRANSFER_NO_FOLLOW_MODELS` setting avoids pulling in pages by association). The importing side needs this mapping entry so that it can determine whether the parent exists or not at the destination, and either create the object under the existing parent or import that parent too, as appropriate.

With this fixed, collections can be successfully imported by ID, including [recognising the root node and avoiding creating a duplicate](https://github.com/wagtail/wagtail-transfer/blob/925a3ba6544672b54737d1399d62fecb25d18d02/wagtail_transfer/operations.py#L308-L312).