### PR TITLE
Fix test for compatibility with Wagtail 2.11 i18n support

### DIFF
--- a/tests/tests/test_api.py
+++ b/tests/tests/test_api.py
@@ -374,7 +374,8 @@ class TestPagesApi(TestCase):
 
         data = json.loads(response.content)
         # result should have a mapping for the page we just created, and its parent
-        self.assertEqual(len(data['mappings']), 2)
+        page_mappings = filter(lambda mapping: mapping[0] == 'wagtailcore.page', data['mappings'])
+        self.assertEqual(len(list(page_mappings)), 2)
 
     def test_parental_many_to_many(self):
         page = PageWithParentalManyToMany(title="This page has lots of ads!")


### PR DESCRIPTION
Pre-emptively fixing a test failure that occurs on Wagtail master - Page now has a foreign key to Locale, so an extra mapping gets pulled along affecting the result count.

(note, we might need to revisit this when 2.11 is released - we probably want Locale objects to be looked up on the language code field as per WAGTAILTRANSFER_LOOKUP_FIELDS so that we don't import them as duplicates.)