### PR TITLE
Fix problem transferring a StreamField block featuring a model that uses MTI

### DIFF
--- a/wagtail_transfer/streamfield.py
+++ b/wagtail_transfer/streamfield.py
@@ -3,6 +3,7 @@ from functools import partial
 from wagtail.core.blocks import (ChooserBlock, ListBlock, RichTextBlock, StreamBlock,
                                  StructBlock)
 
+from .models import get_base_model
 from .richtext import get_reference_handler
 
 
@@ -107,11 +108,11 @@ class RichTextBlockHandler(BaseBlockHandler):
 class ChooserBlockHandler(BaseBlockHandler):
     def get_object_references(self, value):
         if value:
-            return {(self.block.target_model, value)}
+            return {(get_base_model(self.block.target_model), value)}
         return set()
 
     def update_ids(self, value, destination_ids_by_source):
-        value = destination_ids_by_source.get((self.block.target_model, value), value)
+        value = destination_ids_by_source.get((get_base_model(self.block.target_model), value), value)
         return value
 
 


### PR DESCRIPTION
This changeset fixes a `KeyError` when a StreamField features a block which itself involves a model that uses multi-table inheritance.

The KeyError was being raised here: https://github.com/wagtail/wagtail-transfer/blob/master/wagtail_transfer/operations.py#L65

While the Wagtail Transfer docs point out that the `preseed_transfer_table` management command and the `WAGTAILTRANSFER_UPDATE_RELATED_MODELS` should **not** reference models that use multi-table inheritance, it is still possible to use such models with W-T, as long as the original, concrete superclass is the one that is specified. However, the `ChooserBlockHandler` did not support the notion of MTI, and instead assumed the model was a single-table concrete one.

The change to use `get_base_model` brings the code into line with the approach elsewhere in the codebase.

(This solution is 100% from @jacobtm - I'm just implementing it because I need it sooner than he has time for -- thanks Jacob! :o) )