### PR TITLE
Support a configurable timeout for the API chooser proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ The following settings are additionally recognised:
 
 Note that these settings do not accept models that are defined as subclasses through [multi-table inheritance](https://docs.djangoproject.com/en/stable/topics/db/models/#multi-table-inheritance) - in particular, they cannot be used to define behaviour that only applies to specific subclasses of Page.
 
+* `WAGTAILTRANSFER_CHOOSER_API_PROXY_TIMEOUT = 5`
+
+  By default, each API call made to browse the page tree on the source server has a timeout limit of 5 seconds. If you find this threshold is too low, you can increase it. This may be of particular use if you are running two local runservers to test or extend Wagtail Transfer.
 
 ## Management commands
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -87,6 +87,12 @@ that object will end up with unresolved references, to be handled by the same se
 Note that these settings do not accept models that are defined as subclasses through multi-table inheritance - in 
 particular, they cannot be used to define behaviour that only applies to specific subclasses of Page.
 
+```python
+WAGTAILTRANSFER_CHOOSER_API_PROXY_TIMEOUT = 5
+```
+
+  By default, each API call made to browse the page tree on the source server has a timeout limit of 5 seconds. If you find this threshold is too low, you can increase it. This may be of particular use if you are running two local runservers to test or extend Wagtail Transfer.
+
 ## Hooks
 
 ### `register_field_adapters`

--- a/wagtail_transfer/views.py
+++ b/wagtail_transfer/views.py
@@ -168,6 +168,8 @@ class PageChooserAPIViewSet(PagesAdminAPIViewSet):
 def chooser_api_proxy(request, source_name, path):
     source_config = getattr(settings, 'WAGTAILTRANSFER_SOURCES', {}).get(source_name)
 
+    api_proxy_timeout_seconds = getattr(settings, 'WAGTAILTRANSFER_CHOOSER_API_PROXY_TIMEOUT', 5)
+
     if source_config is None:
         raise Http404("Source does not exist")
 
@@ -179,7 +181,7 @@ def chooser_api_proxy(request, source_name, path):
 
     response = requests.get(f"{base_url}{path}?{request.GET.urlencode()}", headers={
         'Accept': request.META['HTTP_ACCEPT'],
-    }, timeout=5)
+    }, timeout=api_proxy_timeout_seconds)
 
     return HttpResponse(response.content, status=response.status_code)
 


### PR DESCRIPTION
This micro change allows for a more relaxed timeout for the chooser API calls to the source server.

The current default behaviour of 5 seconds is retained, but can be overridden via settings.WAGTAILTRANSFER_CHOOSER_API_PROXY_TIMEOUT

Resolves #53 