### PR TITLE
Update default for LOOKUP_FIELDS to include tags

### DIFF
--- a/wagtail_transfer/locators.py
+++ b/wagtail_transfer/locators.py
@@ -19,7 +19,9 @@ UUID_SEQUENCE = 0
 
 # dict of models that should be located by field values using FieldLocator,
 # rather than by UUID mapping
-LOOKUP_FIELDS = {}
+LOOKUP_FIELDS = {
+    'taggit.tag': ['slug'],  # sensible default for taggit; can still be overridden 
+}
 for model_label, fields in getattr(settings, 'WAGTAILTRANSFER_LOOKUP_FIELDS', {}).items():
     LOOKUP_FIELDS[model_label.lower()] = fields
 


### PR DESCRIPTION
In order to get tags to transfer, `WAGTAILTRANSFER_LOOKUP_FIELDS` needs `'taggit.tag': ['slug']` adding to it. @jacobtoppm  suggested we make this a default, because it's necessary to get `taggit` tags to work, which are core to Wagtail anyway.

Micro-PR, which I'm told has test coverage already