### PR TITLE
Support custom/pluggable serializers

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -139,3 +139,36 @@ def register_my_custom_adapter():
     return {models.Field: MyCustomAdapter}
 
 ```
+
+
+### `register_custom_serializers`
+
+In exceptional cases, such as limiting the fields you export to only a subset of the content, you may need to use a custom serializer instead of the default `PageSerializer`.
+You can register a custom serializer by using the `register_custom_serializers` hook.
+A function registered with this hook should return a dictionary which maps model classes to serializer classes (note that with inheritance, the serializer registered with the closest ancestor class will be used).
+For example, to register a custom serializer against `myapp.MyModel`:
+
+```python
+# <my_app>/wagtail_hooks.py
+
+
+from wagtail.core import hooks
+from wagtail_transfer.serializers import PageSerializer
+
+from myapp.models import MyModel
+
+class MyModelCustomSerializer(PageSerializer):
+
+    ignored_fields = PageSerializer.ignored_fields + [
+        'secret_field_1',
+        'environment_specific_data_field_123',
+        ...
+    ]
+    pass
+
+
+@hooks.register('register_custom_serializers')
+def register_my_custom_serializer():
+    return {MyModel: MyModelCustomSerializer}
+
+```

--- a/wagtail_transfer/field_adapters.py
+++ b/wagtail_transfer/field_adapters.py
@@ -230,7 +230,7 @@ class ManyToOneRelAdapter(FieldAdapter):
 
             return {child for child in self._get_related_objects(instance) if child.pk not in matched_destination_ids}
         return set()
-    
+
     def get_objects_to_serialize(self, instance):
         if self.is_parental:
             return getattr(instance, self.name).all()
@@ -372,14 +372,15 @@ class AdapterRegistry:
     def __init__(self):
         self._scanned_for_adapters = False
         self.adapters_by_field_class = {}
-    
+
     def _scan_for_adapters(self):
         adapters = dict(self.BASE_ADAPTERS_BY_FIELD_CLASS)
 
         for fn in hooks.get_hooks('register_field_adapters'):
             adapters.update(fn())
-    
+
         self.adapters_by_field_class = adapters
+        self._scanned_for_adapters = True
 
     @lru_cache(maxsize=None)
     def get_field_adapter(self, field):

--- a/wagtail_transfer/views.py
+++ b/wagtail_transfer/views.py
@@ -16,7 +16,7 @@ from .auth import check_digest, digest_for_source
 from .locators import get_locator_for_model
 from .models import get_model_for_path
 from .operations import ImportPlanner
-from .serializers import get_model_serializer
+from .serializers import serializer_registry
 from .vendor.wagtail_admin_api.serializers import AdminPageSerializer
 from .vendor.wagtail_admin_api.views import PagesAdminAPIViewSet
 
@@ -43,7 +43,7 @@ def pages_for_export(request, root_page_id):
 
     while models_to_serialize:
         model = models_to_serialize.pop()
-        serializer = get_model_serializer(type(model))
+        serializer = serializer_registry.get_model_serializer(type(model))
         objects.append(serializer.serialize(model))
         object_references.update(serializer.get_object_references(model))
         models_to_serialize.update(serializer.get_objects_to_serialize(model).difference(serialized_models))
@@ -92,7 +92,7 @@ def models_for_export(request, model_path, object_id=None):
 
     while models_to_serialize:
         model = models_to_serialize.pop()
-        serializer = get_model_serializer(type(model))
+        serializer = serializer_registry.get_model_serializer(type(model))
         objects.append(serializer.serialize(model))
         object_references.update(serializer.get_object_references(model))
         models_to_serialize.update(serializer.get_objects_to_serialize(model).difference(serialized_models))
@@ -134,12 +134,12 @@ def objects_for_export(request):
 
     for model_path, ids in request_data.items():
         model = get_model_for_path(model_path)
-        serializer = get_model_serializer(model)
+        serializer = serializer_registry.get_model_serializer(model)
 
         models_to_serialize.update(serializer.get_objects_by_ids(ids))
         while models_to_serialize:
             instance = models_to_serialize.pop()
-            serializer = get_model_serializer(type(instance))
+            serializer = serializer_registry.get_model_serializer(type(instance))
             objects.append(serializer.serialize(instance))
             object_references.update(serializer.get_object_references(instance))
             models_to_serialize.update(serializer.get_objects_to_serialize(instance).difference(serialized_models))


### PR DESCRIPTION
This changeset adds support for registering custom page serializers via a wagtail hook.

One use-case is that one might want to exclude certain fields on certain models from transfer (eg fields which contain data only relevant to one environment). 

I'm hoping to also use it to enable cross-codebase use of Wagtail Transfer, so `oldproj.myoldapp.Foo` can be imported into `newproj.differentapp.Foo`

This work its lead from https://github.com/wagtail/wagtail-transfer/pull/46/

There are no tests, but I shall be manually testing this _a lot_ as part of my work. Formal tests can be added if desired, of course. 