### PR TITLE
Add BasicAuth to transfer API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ Developed by [Torchbox](https://torchbox.com/) and sponsored by [The Motley Fool
 
   `WAGTAILTRANSFER_SECRET_KEY` and the per-source `SECRET_KEY` settings are used to authenticate the communication between the source and destination instances; this prevents unauthorised users from using this API to retrieve sensitive data such as password hashes. The `SECRET_KEY` for each entry in `WAGTAILTRANSFER_SOURCES` must match that instance's `WAGTAILTRANSFER_SECRET_KEY`.
 
+* If any source sites use Basic Access Authentication insert an additional dict key `BASIC_AUTH` with the (username, password) tuple:
+
+      WAGTAILTRANSFER_SOURCES = {
+          'staging': {
+              'BASE_URL': 'https://staging.example.com/wagtail-transfer/',
+              'SECRET_KEY': '4ac4822149691395773b2a8942e1a472',
+              'BASIC_AUTH': ('testing', 'super-secret'),
+          },
+      }
 
 ## Configuration
 

--- a/tests/tests/test_api.py
+++ b/tests/tests/test_api.py
@@ -637,7 +637,7 @@ class TestChooserProxyApi(TestCase):
 
         response = self.client.get('/admin/wagtail-transfer/api/chooser-proxy/staging/foo?bar=baz', HTTP_ACCEPT='application/json')
 
-        get.assert_called_once_with('https://www.example.com/wagtail-transfer/api/chooser/pages/foo?bar=baz', headers={'Accept': 'application/json'}, timeout=5)
+        get.assert_called_once_with('https://www.example.com/wagtail-transfer/api/chooser/pages/foo?bar=baz', auth=None, headers={'Accept': 'application/json'}, timeout=5)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, b'test content')

--- a/wagtail_transfer/auth.py
+++ b/wagtail_transfer/auth.py
@@ -31,3 +31,9 @@ def digest_for_source(source, message):
         message = message.encode()
 
     return hmac.new(key, message, hashlib.sha1).hexdigest()
+
+def requests_auth(source):
+    try:
+        return settings.WAGTAILTRANSFER_SOURCES[source]['BASIC_AUTH']
+    except:
+        return None

--- a/wagtail_transfer/field_adapters.py
+++ b/wagtail_transfer/field_adapters.py
@@ -308,7 +308,7 @@ class FileAdapter(FieldAdapter):
             name = pathlib.PurePosixPath(urlparse(value['download_url']).path).name
             local_filename = self.field.generate_filename(instance, name)
 
-            _file = File(local_filename, value['size'], value['hash'], value['download_url'])
+            _file = File(local_filename, value['size'], value['hash'], value['download_url'], context.source_site)
             try:
                 imported_file = _file.transfer()
             except FileTransferError:

--- a/wagtail_transfer/files.py
+++ b/wagtail_transfer/files.py
@@ -5,6 +5,7 @@ import requests
 from django.core.files.base import ContentFile
 
 from .models import ImportedFile
+from .auth import requests_auth
 
 
 @contextmanager
@@ -90,20 +91,23 @@ class FileTransferError(Exception):
     pass
 
 
+import traceback
+
 class File:
     """
     Represents a file that needs to be imported
 
     Note that local_filename is only a guideline, it may be changed to avoid conflict with an existing file
     """
-    def __init__(self, local_filename, size, hash, source_url):
+    def __init__(self, local_filename, size, hash, source_url, source_site):
         self.local_filename = local_filename
         self.size = size
         self.hash = hash
         self.source_url = source_url
+        self.source_site = source_site
 
     def transfer(self):
-        response = requests.get(self.source_url)
+        response = requests.get(self.source_url, auth=requests_auth(self.source_site))
 
         if response.status_code != 200:
             raise FileTransferError("Non-200 response from image URL")

--- a/wagtail_transfer/operations.py
+++ b/wagtail_transfer/operations.py
@@ -99,7 +99,7 @@ class ImportContext:
     (for example, once a page is created at the destination, we add its ID mapping so that we
     can handle references to it that appear in other imported pages).
     """
-    def __init__(self):
+    def __init__(self, source_site):
         # A mapping of objects on the source site to their IDs on the destination site.
         # Keys are tuples of (model_class, source_id); values are destination IDs.
         # model_class must be the highest concrete model in the inheritance tree - i.e.
@@ -113,9 +113,12 @@ class ImportContext:
         # Mapping of source_urls to instances of ImportedFile
         self.imported_files_by_source_url = {}
 
+        # Source name
+        self.source_site = source_site
+
 
 class ImportPlanner:
-    def __init__(self, root_page_source_pk=None, destination_parent_id=None, model=None):
+    def __init__(self, root_page_source_pk=None, destination_parent_id=None, model=None, source_site=None):
 
         if root_page_source_pk or destination_parent_id:
             self.import_type = 'page'
@@ -130,7 +133,7 @@ class ImportPlanner:
         else:
             raise NotImplementedError("Missing page kwargs or specified model kwarg")
 
-        self.context = ImportContext()
+        self.context = ImportContext(source_site)
 
         self.objectives = set()
 
@@ -181,12 +184,12 @@ class ImportPlanner:
         self.failed_creations = set()
 
     @classmethod
-    def for_page(cls, source, destination):
-        return cls(root_page_source_pk=source, destination_parent_id=destination)
+    def for_page(cls, source, destination, source_site):
+        return cls(root_page_source_pk=source, destination_parent_id=destination, source_site=source_site)
 
     @classmethod
-    def for_model(cls, model):
-        return cls(model=model)
+    def for_model(cls, model, source_site):
+        return cls(model=model, source_site=source_site)
 
     def add_json(self, json_data):
         """


### PR DESCRIPTION
This PR adds a Basic Auth capability to Wagtail-Transfer API requests. This is useful if a source site is protected with Basic Auth.

The rationale for this, in my case, is to use Basic Auth to protect a testing/staging site from accidental exposure to unsuspecting readers who may not recognise the difference from the production site. As the site advertises events, the likely fictitious test information on the testing/staging site is likely to mislead. Basic Auth also keeps unscrupulous bots out.

Basic Auth works fine with browsers, but is clearly _mission over_ in the case of Wagtail-Transfer.

Adding the `auth` parameter to the various `requests.get()`/`post()` calls was quite straightforward except for the call that transfers image files in `files.py`. In that case I've carried the source site name (eg. "staging") via the `ImportContext` as I couldn't see another way without changing lots of other function type signatures. Alternative suggestions are welcome.

The new capability and its configuration are documented in the `README.md`.