### PR TITLE
Link deletion

### DIFF
--- a/tests/tests/test_import.py
+++ b/tests/tests/test_import.py
@@ -481,7 +481,7 @@ class TestImport(TestCase):
     def test_do_not_import_pages_outside_of_selected_root(self):
         # Source page 13 is a page we don't have at the destination, but it's not in ids_for_import
         # (i.e. it's outside of the selected import root), so we shouldn't import it, and should
-        # leave references in rich text unchanged
+        # remove links in rich text
         data = """{
             "ids_for_import": [
                 ["wagtailcore.page", 15]
@@ -513,8 +513,8 @@ class TestImport(TestCase):
 
         page = PageWithRichText.objects.get(slug="imported-rich-text-page")
 
-        # tests that the page link id is unchanged
-        self.assertEqual(page.body, '<p>But I have a <a id="13" linktype="page">link</a></p>')
+        # tests that the page link tag is removed, as the page does not exist on the destination
+        self.assertEqual(page.body, '<p>But I have a link</p>')
 
     def test_import_page_with_streamfield_page_links(self):
         data = """{

--- a/wagtail_transfer/field_adapters.py
+++ b/wagtail_transfer/field_adapters.py
@@ -266,7 +266,7 @@ class StreamFieldAdapter(FieldAdapter):
 
     def get_dependencies(self, value):
         return {
-            (model, id, False)  # references in rich text are soft dependencies
+            (model, id, False)  # references in streamfield are soft dependencies
             for model, id in get_object_references(self.stream_block, json.loads(value))
         }
 

--- a/wagtail_transfer/streamfield.py
+++ b/wagtail_transfer/streamfield.py
@@ -69,31 +69,35 @@ class BaseBlockHandler:
 
 class ListBlockHandler(BaseBlockHandler):
     def map_over_json(self, stream, func):
+        updated_stream = []
         new_block = self.block.child_block
         new_block_handler = get_block_handler(new_block)
-        for index, element in enumerate(stream):
-            stream[index] = new_block_handler.map_over_json(element, func)
-        return stream
+        for element in stream:
+            updated_stream.append(new_block_handler.map_over_json(element, func))
+        return updated_stream
 
 
 class StreamBlockHandler(BaseBlockHandler):
     def map_over_json(self, stream, func):
+        updated_stream = []
         for element in stream:
             new_block = self.block.child_blocks.get(element['type'])
             new_block_handler = get_block_handler(new_block)
             new_stream = element['value']
-            element['value'] = new_block_handler.map_over_json(new_stream, func)
-        return stream
+            updated_stream.append({'type': element['type'], 'value': new_block_handler.map_over_json(new_stream, func), 'id': element['id']})
+        return updated_stream
 
 
 class StructBlockHandler(BaseBlockHandler):
     def map_over_json(self, stream, func):
+        updated_stream = {}
         for key in stream:
             new_block = self.block.child_blocks.get(key)
             new_block_handler = get_block_handler(new_block)
             new_stream = stream[key]
-            stream[key] = new_block_handler.map_over_json(new_stream, func)
-        return stream
+            new_value = new_block_handler.map_over_json(new_stream, func)
+            updated_stream[key] = new_value
+        return updated_stream
 
 
 class RichTextBlockHandler(BaseBlockHandler):

--- a/wagtail_transfer/streamfield.py
+++ b/wagtail_transfer/streamfield.py
@@ -112,7 +112,7 @@ class ChooserBlockHandler(BaseBlockHandler):
         return set()
 
     def update_ids(self, value, destination_ids_by_source):
-        value = destination_ids_by_source.get((get_base_model(self.block.target_model), value), value)
+        value = destination_ids_by_source.get((get_base_model(self.block.target_model), value))
         return value
 
 


### PR DESCRIPTION
This PR standardises the FieldAdapter approach for rewriting references when a model is missing on the destination side:
- In rich text, removing the link tag (but leaving the text), rather than leaving a potentially broken link to the original instance's id
- In streamfield, removing the reference, and potentially removing the block if it is set as required, along with logic for structural blocks to be similarly removed if a required child is missing