### PR TITLE
Add wagtailcore.locale to default LOOKUP_FIELDS setting

### DIFF
--- a/wagtail_transfer/locators.py
+++ b/wagtail_transfer/locators.py
@@ -21,6 +21,7 @@ UUID_SEQUENCE = 0
 # rather than by UUID mapping
 LOOKUP_FIELDS = {
     'taggit.tag': ['slug'],  # sensible default for taggit; can still be overridden 
+    'wagtailcore.locale': ["language_code"]
 }
 for model_label, fields in getattr(settings, 'WAGTAILTRANSFER_LOOKUP_FIELDS', {}).items():
     LOOKUP_FIELDS[model_label.lower()] = fields


### PR DESCRIPTION
This is needed for 2.11 compatibility to avoid trying to reimport an existing locale