### PR TITLE
Add decorator to authenticate all page chooser api requests

### DIFF
--- a/tests/tests/test_views.py
+++ b/tests/tests/test_views.py
@@ -9,6 +9,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from tests.models import SponsoredPage
+from wagtail_transfer.auth import digest_for_source
 from wagtail_transfer.models import IDMapping
 
 
@@ -281,7 +282,9 @@ class TestImportView(TestCase):
 
     def test_list_snippet_models(self, get, post):
         # Test the model chooser view.
-        response = self.client.get("https://www.example.com/wagtail-transfer/api/chooser/models/?models=True")
+        get_params = "models=True"
+        digest = digest_for_source('local', get_params)
+        response = self.client.get(f"https://www.example.com/wagtail-transfer/api/chooser/models/?{get_params}&digest={digest}")
         self.assertEqual(response.status_code, 200)
 
         content = json.loads(response.content.decode("utf-8"))

--- a/wagtail_transfer/auth.py
+++ b/wagtail_transfer/auth.py
@@ -28,6 +28,13 @@ def check_get_digest_wrapper(view_func):
         # Unfortunately the admin API views won't allow unknown GET parameters
         # So we must remove the digest parameter from the request as well
         request.META['QUERY_STRING'] = message
+
+        # Normally request.GET shouldn't be evaluated yet, but in case someone's
+        # inspecting it in middleware for example, let's remove the cached version,
+        # otherwise it will retain the old digest parameter
+        if hasattr(request, 'GET'):
+            del request.GET
+
         response = view_func(request, *args, **kwargs)
         return response
     return decorated_view

--- a/wagtail_transfer/auth.py
+++ b/wagtail_transfer/auth.py
@@ -1,8 +1,36 @@
 import hashlib
 import hmac
+import re
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
+
+GROUP_QUERY_WITH_DIGEST = re.compile('(?P<query_before>.*?)&?digest=(?P<digest>[^&]*)(?P<query_after>.*)')
+
+def check_get_digest_wrapper(view_func):
+    """
+    Check the digest of a request matches its GET parameters
+    This is useful when wrapping vendored API views
+    """
+    def decorated_view(request, *args, **kwargs):
+        query_string = request.META.get('QUERY_STRING', '')
+        match = GROUP_QUERY_WITH_DIGEST.match(query_string)
+        if not match:
+            raise PermissionDenied
+        digest = match.group('digest')
+        message = f'{match.group("query_before")}{match.group("query_after")}'
+        if not (digest and message):
+            # This decorator is intended for use with GET parameters
+            # If there are none, or no digest, something's gone wrong
+            raise PermissionDenied
+        check_digest(message, digest)
+
+        # Unfortunately the admin API views won't allow unknown GET parameters
+        # So we must remove the digest parameter from the request as well
+        request.META['QUERY_STRING'] = message
+        response = view_func(request, *args, **kwargs)
+        return response
+    return decorated_view
 
 
 def check_digest(message, digest):

--- a/wagtail_transfer/urls.py
+++ b/wagtail_transfer/urls.py
@@ -1,7 +1,10 @@
 from django.conf.urls import url
 from django.urls import path
 
+from wagtail.utils.urlpatterns import decorate_urlpatterns
+
 from wagtail_transfer import views
+from wagtail_transfer.auth import check_get_digest_wrapper
 from wagtail_transfer.vendor.wagtail_api_v2.views import ModelsAPIViewSet
 
 from .vendor.wagtail_api_v2.router import WagtailAPIRouter
@@ -15,5 +18,5 @@ urlpatterns = [
     path('api/models/<str:model_path>/', views.models_for_export, name='wagtail_transfer_model'),
     path('api/models/<str:model_path>/<int:object_id>/', views.models_for_export, name='wagtail_transfer_model_object'),
     url(r'^api/objects/$', views.objects_for_export, name='wagtail_transfer_objects'),
-    url(r'^api/chooser/', chooser_api.urls),
+    url(r'^api/chooser/', (decorate_urlpatterns(chooser_api.get_urlpatterns(), check_get_digest_wrapper), chooser_api.url_namespace, chooser_api.url_namespace)),
 ]

--- a/wagtail_transfer/views.py
+++ b/wagtail_transfer/views.py
@@ -198,7 +198,10 @@ def chooser_api_proxy(request, source_name, path):
 
     base_url = source_config['BASE_URL'] + 'api/chooser/{}/'.format(default_chooser_endpoint)
 
-    response = requests.get(f"{base_url}{path}?{request.GET.urlencode()}", headers={
+    message = request.GET.urlencode()
+    digest = digest_for_source(source_name, message)
+
+    response = requests.get(f"{base_url}{path}?{message}&digest={digest}", headers={
         'Accept': request.META['HTTP_ACCEPT'],
     }, timeout=api_proxy_timeout_seconds)
 


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail-transfer/issues/72

This uses a decorator to wrap the API urlpatterns, using the GET parameters as the "message" to compare to the digest. This is done in place of modifying the vendored endpoint in order to avoid meddling too much with the code, especially in case it is accidentally overwritten on an upgrade