### PR TITLE
Add default_auto_field to prevent warnings under Django 3.2

### DIFF
--- a/tests/apps.py
+++ b/tests/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class WagtailTransferTestsAppConfig(AppConfig):
+    name = 'tests'
+    default_auto_field = 'django.db.models.AutoField'

--- a/wagtail_transfer/apps.py
+++ b/wagtail_transfer/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class WagtailTransferAppConfig(AppConfig):
+    name = 'wagtail_transfer'
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
Silences warnings such as: tests.Advert: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.