### PR TITLE
Fix migrations for Wagtail <2.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,15 +5,19 @@ orbs:
 
 jobs:
   build-and-test:
+    parameters:
+      wagtail-version:
+        default: "wagtail"
+        type: string
     executor: python/default
     steps:
       - checkout
       - restore_cache:
-          key: pip-{{ .Branch }}
-      - run: pip install wagtail
+          key: pip-{{ .Branch }}-<< parameters.wagtail-version >>
+      - run: pip install "<< parameters.wagtail-version >>"
       - run: pip install -e .
       - save_cache:
-          key: pip-{{ .Branch }}
+          key: pip-{{ .Branch }}-<< parameters.wagtail-version >>
           paths:
             - "~/.cache/pip"
       - run:
@@ -35,7 +39,14 @@ jobs:
 workflows:
   main:
     jobs:
-      - build-and-test
+      - build-and-test:
+          wagtail-version: "wagtail"
+      - build-and-test:
+          wagtail-version: "wagtail>=2.8,<2.9"
+      - build-and-test:
+          wagtail-version: "wagtail>=2.10,<2.11"
+      - build-and-test:
+          wagtail-version: "wagtail>=2.12,<2.13"
   nightly:
     jobs:
       - nightly-wagtail-test

--- a/wagtail_transfer/migrations/0003_permissions.py
+++ b/wagtail_transfer/migrations/0003_permissions.py
@@ -39,7 +39,7 @@ class Migration(migrations.Migration):
     dependencies = [
         ("auth", "0011_update_proxy_permissions"),
         ("contenttypes", "0002_remove_content_type_name"),
-        ("wagtailcore", "0060_fix_workflow_unique_constraint"),
+        ("wagtailcore", "0040_page_draft_title"),
         ("wagtail_transfer", "0002_importedfile"),
     ]
 


### PR DESCRIPTION
#87 introduced a migration with a dependency on `wagtailcore.0060_fix_workflow_unique_constraint`, which only existed as of Wagtail 2.12 and fails on older versions. I can't immediately see why that migration needs to depend on wagtailcore at all, but to avoid disrupting things too much I've changed it to 0040 (which is present on all Wagtail 2.x releases) so that at least the initial wagtailcore migrations have run.

Also update our circleci config to test against older Wagtail releases, to catch this kind of thing in future...