### PR TITLE
Fix urlconfs for Django 4.0 support

### DIFF
--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
@@ -8,10 +8,10 @@ from wagtail_transfer import urls as wagtailtransfer_urls
 
 
 urlpatterns = [
-    url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'^wagtail-transfer/', include(wagtailtransfer_urls)),
+    re_path(r'^admin/', include(wagtailadmin_urls)),
+    re_path(r'^wagtail-transfer/', include(wagtailtransfer_urls)),
 
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's serving mechanism
-    url(r'', include(wagtail_urls)),
+    re_path(r'', include(wagtail_urls)),
 ]

--- a/wagtail_transfer/admin_urls.py
+++ b/wagtail_transfer/admin_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from wagtail_transfer import views
 
@@ -9,9 +9,9 @@ chooser_api.register_endpoint('pages', views.PageChooserAPIViewSet)
 
 app_name = 'wagtail_transfer_admin'
 urlpatterns = [
-    url(r'^choose/$', views.choose_page, name='choose_page'),
-    url(r'^import/$', views.do_import, name='import'),
-    url(r'^api/chooser-local/', (chooser_api.urls[0], 'page_chooser_api', 'page_chooser_api')),
-    url(r'^api/chooser-proxy/(\w+)/([\w\-/]*)$', views.chooser_api_proxy, name='chooser_api_proxy'),
-    url(r'^api/check_uid/$', views.check_page_existence_for_uid, name='check_uid'),
+    re_path(r'^choose/$', views.choose_page, name='choose_page'),
+    re_path(r'^import/$', views.do_import, name='import'),
+    re_path(r'^api/chooser-local/', (chooser_api.urls[0], 'page_chooser_api', 'page_chooser_api')),
+    re_path(r'^api/chooser-proxy/(\w+)/([\w\-/]*)$', views.chooser_api_proxy, name='chooser_api_proxy'),
+    re_path(r'^api/check_uid/$', views.check_page_existence_for_uid, name='check_uid'),
 ]

--- a/wagtail_transfer/urls.py
+++ b/wagtail_transfer/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import url
-from django.urls import path
+from django.urls import path, re_path
 
 from wagtail.utils.urlpatterns import decorate_urlpatterns
 
@@ -14,9 +13,9 @@ chooser_api.register_endpoint('pages', views.PageChooserAPIViewSet)
 chooser_api.register_endpoint('models', ModelsAPIViewSet)
 
 urlpatterns = [
-    url(r'^api/pages/(\d+)/$', views.pages_for_export, name='wagtail_transfer_pages'),
+    re_path(r'^api/pages/(\d+)/$', views.pages_for_export, name='wagtail_transfer_pages'),
     path('api/models/<str:model_path>/', views.models_for_export, name='wagtail_transfer_model'),
     path('api/models/<str:model_path>/<int:object_id>/', views.models_for_export, name='wagtail_transfer_model_object'),
-    url(r'^api/objects/$', views.objects_for_export, name='wagtail_transfer_objects'),
-    url(r'^api/chooser/', (decorate_urlpatterns(chooser_api.get_urlpatterns(), check_get_digest_wrapper), chooser_api.url_namespace, chooser_api.url_namespace)),
+    re_path(r'^api/objects/$', views.objects_for_export, name='wagtail_transfer_objects'),
+    re_path(r'^api/chooser/', (decorate_urlpatterns(chooser_api.get_urlpatterns(), check_get_digest_wrapper), chooser_api.url_namespace, chooser_api.url_namespace)),
 ]

--- a/wagtail_transfer/vendor/wagtail_api_v2/router.py
+++ b/wagtail_transfer/vendor/wagtail_api_v2/router.py
@@ -1,6 +1,6 @@
 import functools
 
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from wagtail.utils.urlpatterns import decorate_urlpatterns
 
 
@@ -67,7 +67,7 @@ class WagtailAPIRouter:
         urlpatterns = []
 
         for name, class_ in self._endpoints.items():
-            pattern = url(
+            pattern = re_path(
                 r'^{}/'.format(name),
                 include((class_.get_urlpatterns(), name), namespace=name)
             )
@@ -84,6 +84,6 @@ class WagtailAPIRouter:
 
         Use with Django's include() function:
 
-            url(r'api/', include(myapi.urls)),
+            re_path(r'api/', include(myapi.urls)),
         """
         return self.get_urlpatterns(), self.url_namespace, self.url_namespace

--- a/wagtail_transfer/vendor/wagtail_api_v2/views.py
+++ b/wagtail_transfer/vendor/wagtail_api_v2/views.py
@@ -1,11 +1,10 @@
 from collections import OrderedDict
 
 from django.apps import apps
-from django.conf.urls import url
 from django.core.exceptions import FieldDoesNotExist
 from django.http import Http404
 from django.shortcuts import redirect
-from django.urls import reverse
+from django.urls import re_path, reverse
 from modelcluster.fields import ParentalKey
 from rest_framework import status
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
@@ -338,9 +337,9 @@ class BaseAPIViewSet(GenericViewSet):
         This returns a list of URL patterns for the endpoint
         """
         return [
-            url(r'^$', cls.as_view({'get': 'listing_view'}), name='listing'),
-            url(r'^(?P<pk>\d+)/$', cls.as_view({'get': 'detail_view'}), name='detail'),
-            url(r'^find/$', cls.as_view({'get': 'find_view'}), name='find'),
+            re_path(r'^$', cls.as_view({'get': 'listing_view'}), name='listing'),
+            re_path(r'^(?P<pk>\d+)/$', cls.as_view({'get': 'detail_view'}), name='detail'),
+            re_path(r'^find/$', cls.as_view({'get': 'find_view'}), name='find'),
         ]
 
     @classmethod
@@ -573,6 +572,6 @@ class ModelsAPIViewSet(GenericViewSet):
         This returns a list of URL patterns for the endpoint
         """
         return [
-            url(r'^$', cls.as_view({'get': 'listing_view'}), name='listing'),
-            url(r'^(?P<model_path>[-\w.]+)/$', cls.as_view({'get': 'detail_view'}), name='detail'),
+            re_path(r'^$', cls.as_view({'get': 'listing_view'}), name='listing'),
+            re_path(r'^(?P<model_path>[-\w.]+)/$', cls.as_view({'get': 'detail_view'}), name='detail'),
         ]

--- a/wagtail_transfer/wagtail_hooks.py
+++ b/wagtail_transfer/wagtail_hooks.py
@@ -1,6 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include, url
-from django.urls import reverse
+from django.urls import include, re_path, reverse
 from wagtail.admin.menu import MenuItem
 from wagtail.core import hooks
 from django.contrib.auth.models import Permission
@@ -18,7 +17,7 @@ except ImportError:
 @hooks.register('register_admin_urls')
 def register_admin_urls():
     return [
-        url(r'^wagtail-transfer/', include(admin_urls, namespace='wagtail_transfer_admin')),
+        re_path(r'^wagtail-transfer/', include(admin_urls, namespace='wagtail_transfer_admin')),
     ]
 
 


### PR DESCRIPTION
Use django.urls.re_path instead of django.conf.urls.url. django.urls.re_path has been available since Django 2.0, so this does not break any supported configurations.