### PR TITLE
Prevent FileFieldAdapter adding `BASE_URL` to absolute URLs

### DIFF
--- a/wagtail_transfer/field_adapters.py
+++ b/wagtail_transfer/field_adapters.py
@@ -280,7 +280,7 @@ class FileAdapter(FieldAdapter):
         if not value:
             return None
         url = value.url
-        if settings.MEDIA_URL.startswith('/'):
+        if url.startswith('/'):
             # Using a relative media url. ie. /media/
             # Prepend the BASE_URL to turn this into an absolute URL
             url = settings.BASE_URL.rstrip('/') + url


### PR DESCRIPTION
Closes #107 