### PR TITLE
Wagtail 3.0 compatibility fixes

### DIFF
--- a/wagtail_transfer/static/wagtail_transfer/css/transfer-styles.css
+++ b/wagtail_transfer/static/wagtail_transfer/css/transfer-styles.css
@@ -1,6 +1,13 @@
 .transfer.button.button-secondary.bicolor {
     overflow: visible;
     border: 1px solid #00676a;
+    width: auto;
+    color: #007d7e;
+    height: 3em;
+}
+
+.transfer.button.button-secondary.bicolor:hover {
+    color: #fff;
 }
 
 .transfer.button.button-secondary.bicolor::before {


### PR DESCRIPTION
Recognise WAGTAILADMIN_BASE_URL in preference to BASE_URL, and fix button styling (which was also broken as far back as Wagtail 2.13).