### PR TITLE
Don't import _editor_css.html on Wagtail >=4

### DIFF
--- a/wagtail_transfer/templates/wagtail_transfer/choose_page.html
+++ b/wagtail_transfer/templates/wagtail_transfer/choose_page.html
@@ -4,7 +4,9 @@
 {% block extra_css %}
     {{ block.super }}
 
-    {% include "wagtailadmin/pages/_editor_css.html" %}
+    {% if include_legacy_editor_css %}
+        {% include "wagtailadmin/pages/_editor_css.html" %}
+    {% endif %}
     <link rel="stylesheet" href="{% versioned_static 'wagtail_transfer/css/transfer-styles.css' %}">
 {% endblock %}
 

--- a/wagtail_transfer/views.py
+++ b/wagtail_transfer/views.py
@@ -227,6 +227,7 @@ def choose_page(request):
             }
             for source_name in getattr(settings, 'WAGTAILTRANSFER_SOURCES', {}).keys()
         ]),
+        'include_legacy_editor_css': WAGTAIL_VERSION < (4, 0),
     })
 
 


### PR DESCRIPTION
The additional CSS is now incorporated into the core admin CSS, and so this include no longer exists.