### PR TITLE
Added support for wagtail 4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,9 @@ workflows:
       - build-and-test:
           wagtail-version: "wagtail>=3.0,<3.1"
           python-version: "3.10"
+      - build-and-test:
+          wagtail-version: "wagtail>=4.0,<4.1"
+          python-version: "3.10"
   nightly:
     jobs:
       - nightly-wagtail-test

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Unreleased
+~~~~~~~~~~~~~~~~~~
+
+ * Add support for Wagtail 4.0 (Katherine Domingo)
+
+
 0.8.5 (18.07.2022)
 ~~~~~~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,6 @@ setup(
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 2',
         'Framework :: Wagtail :: 3',
+        'Framework :: Wagtail :: 4',
     ],
 )

--- a/tests/tests/test_import.py
+++ b/tests/tests/test_import.py
@@ -123,7 +123,11 @@ class TestImport(TestCase):
         self.assertEqual(updated_page.draft_title, "New home")
 
         # get_latest_revision (as used in the edit-page view) should also reflect the imported content
-        updated_page_revision = updated_page.get_latest_revision_as_page()
+        if WAGTAIL_VERSION >= (4, 0):
+            updated_page_revision = updated_page.get_latest_revision_as_object()
+        else:
+            updated_page_revision = updated_page.get_latest_revision_as_page()
+
         self.assertEqual(updated_page_revision.intro, "This is the updated homepage")
         self.assertEqual(updated_page_revision.title, "New home")
 
@@ -131,7 +135,12 @@ class TestImport(TestCase):
         self.assertEqual(created_page.intro, "This page is imported from the source site")
         # An initial page revision should also be created
         self.assertTrue(created_page.get_latest_revision())
-        created_page_revision = created_page.get_latest_revision_as_page()
+
+        if WAGTAIL_VERSION >= (4, 0):
+            created_page_revision = created_page.get_latest_revision_as_object()
+        else:
+            created_page_revision = created_page.get_latest_revision_as_page()
+
         self.assertEqual(created_page_revision.intro, "This page is imported from the source site")
 
     def test_import_pages_with_fk(self):


### PR DESCRIPTION
Release notes: https://docs.wagtail.org/en/stable/releases/4.0.html

- Added test for wagtail 4
- Updated documentation
- Suppressed some warnings for wagtail 4

Tests run OK
```
Found 73 test(s).
Creating test database for alias 'default'...
Adding content type 'wagtail_transfer | idmapping'
Adding content type 'wagtail_transfer | importedfile'
System check identified some issues:

WARNINGS:
?: (wagtailadmin.W003) The WAGTAILADMIN_BASE_URL setting is not defined
        HINT: This should be the base URL used to access the Wagtail admin site. Without this, URLs in notification emails will not display correctly.

System check identified 1 issue (0 silenced).
.../Users/kdomingo/Desktop/torchbox/forks/wagtail-transfer/.venv/lib/python3.9/site-packages/djangorestframework-3.14.0-py3.9.egg/rest_framework/pagination.py:200: UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list: <class 'tests.models.Category'> QuerySet.
  paginator = self.django_paginator_class(queryset, page_size)
......................................................................
----------------------------------------------------------------------
Ran 73 tests in 1.514s

OK
```