### PR TITLE
Check uid type in Field Locator and handle if str

### DIFF
--- a/wagtail_transfer/locators.py
+++ b/wagtail_transfer/locators.py
@@ -127,6 +127,12 @@ class FieldLocator:
     def find(self, uid):
         # pair up field names with their respective items in the UID tuple, to form a filter dict
         # that we can use for an ORM lookup
+        if type(uid) == tuple:
+            filters = dict(zip(self.fields, uid))
+        elif type(uid) == str:
+            # if lookup fields are configured for wagtailcore.page, then in the admin view those
+            # fields get passed along as a string
+            filters = dict(zip(self.fields, uid.split(",")))
         filters = dict(zip(self.fields, uid))
 
         try:


### PR DESCRIPTION
Fixes #133 Currently nothing prevents a setup like ```WAGTAILTRANSFER_LOOKUP_FIELDS = {'wagtailcore.page': ['slug', 'locale_id']}``` from existing,  but this will cause issues trying to look up and match the page due to how it's currently sent in the admin_url
