### PR TITLE
Support wagtail42

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -137,7 +137,7 @@ For example, to register a custom field adapter against Django's `models.Field`:
 
 from django.db import models
 
-from wagtail.core import hooks
+from wagtail import hooks
 from wagtail_transfer.field_adapters import FieldAdapter
 
 
@@ -163,7 +163,7 @@ For example, to register a custom serializer against `myapp.MyModel`:
 # <my_app>/wagtail_hooks.py
 
 
-from wagtail.core import hooks
+from wagtail import hooks
 from wagtail_transfer.serializers import PageSerializer
 
 from myapp.models import MyModel

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Framework :: Django',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 4',

--- a/tests/blocks.py
+++ b/tests/blocks.py
@@ -17,6 +17,7 @@ class BaseStreamBlock(StreamBlock):
     """
     Define the custom blocks that `StreamField` will utilize
     """
+
     link_block = CaptionedPageLink()
     integer = IntegerBlock(required=True)
     page = PageChooserBlock()

--- a/tests/models.py
+++ b/tests/models.py
@@ -49,7 +49,7 @@ class SectionedPage(Page):
 
 
 class SectionedPageSection(Orderable):
-    page = ParentalKey(SectionedPage, related_name='sections')
+    page = ParentalKey(SectionedPage, related_name="sections")
     title = models.CharField(max_length=255)
     body = models.TextField()
 
@@ -71,12 +71,14 @@ class ModelWithManyToMany(models.Model):
 
 
 class Avatar(models.Model):
-    image = models.ImageField(upload_to='avatars')
+    image = models.ImageField(upload_to="avatars")
 
 
 class RedirectPage(Page):
-    redirect_to = models.ForeignKey(Page, blank=False, null=False, on_delete=models.PROTECT, related_name='+')
+    redirect_to = models.ForeignKey(
+        Page, blank=False, null=False, on_delete=models.PROTECT, related_name="+"
+    )
 
 
 class PageWithRelatedPages(Page):
-    related_pages = models.ManyToManyField(Page, related_name='+')
+    related_pages = models.ManyToManyField(Page, related_name="+")

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -146,3 +146,5 @@ WAGTAILTRANSFER_LOOKUP_FIELDS = {
 # 2.13.x (from 2.13.5 onward) and 2.14.x (from 2.14.2 onward) adopt the 2.15 behaviour, allowing us to
 # use the same test fixtures across all versions.
 WAGTAIL_COMMENTS_RELATION_NAME = 'wagtail_admin_comments'
+
+WAGTAILADMIN_BASE_URL = 'http://example.com'

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -142,9 +142,4 @@ WAGTAILTRANSFER_LOOKUP_FIELDS = {
     'tests.category': ['name']
 }
 
-# The default name for the Page -> Comment relation from Wagtail 2.15 onward. Setting this ensures that
-# 2.13.x (from 2.13.5 onward) and 2.14.x (from 2.14.2 onward) adopt the 2.15 behaviour, allowing us to
-# use the same test fixtures across all versions.
-WAGTAIL_COMMENTS_RELATION_NAME = 'wagtail_admin_comments'
-
 WAGTAILADMIN_BASE_URL = 'http://example.com'

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -23,7 +23,6 @@ INSTALLED_APPS = [
     'wagtail.search',
     'wagtail.admin',
     'wagtail',
-
     'modelcluster',
     'taggit',
 


### PR DESCRIPTION
This updates the package for testing against wagtail >= 4.1

Removes:

- Compatibility code and testing for wagtail < v4.1

Updates:

- docs

The test pass locally.

Todo:

- [ ] Test a wagtail 4.1 and 4.2 transfer scenario. 