### PR TITLE
Fix usage of ChooserBlock.target_model

### DIFF
--- a/tests/blocks.py
+++ b/tests/blocks.py
@@ -1,6 +1,7 @@
 from wagtail.blocks import (CharBlock, IntegerBlock, ListBlock,
                             PageChooserBlock, RichTextBlock, StreamBlock,
                             StructBlock)
+from wagtail.documents.blocks import DocumentChooserBlock
 
 
 class CaptionedPageLink(StructBlock):
@@ -24,3 +25,4 @@ class BaseStreamBlock(StreamBlock):
     rich_text = RichTextBlock()
     list_of_pages = ListBlock(PageChooserBlock())
     list_of_captioned_pages = ListBlock(CaptionedPageLink())
+    document = DocumentChooserBlock()

--- a/tests/fixtures/test.json
+++ b/tests/fixtures/test.json
@@ -259,4 +259,27 @@
         "name": "Cars",
         "colour": "red"
     }
-}]
+},
+{
+    "model": "wagtaildocs.document",
+    "pk": 1,
+    "fields":
+    {
+	"collection": 1,
+	"title": "Test document",
+	"file": "documents/document.txt",
+	"created_at": "2023-02-28T15:41:44.991Z",
+	"uploaded_by_user": null,
+	"file_size": null,
+	"file_hash": ""
+    }
+},
+{
+    "pk": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    "model": "wagtail_transfer.idmapping",
+    "fields": {
+        "content_type": ["wagtaildocs", "document"],
+        "local_id": 1
+    }
+}
+]

--- a/tests/tests/test_import.py
+++ b/tests/tests/test_import.py
@@ -646,6 +646,53 @@ class TestImport(TestCase):
         # Check that PageChooserBlock ids are converted correctly to those on the destination site
         self.assertEqual(imported_streamfield, [{'type': 'link_block', 'value': {'page': 1, 'text': 'Test'}, 'id': 'fc3b0d3d-d316-4271-9e31-84919558188a'}, {'type': 'page', 'value': 2, 'id': 'c6d07d3a-72d4-445e-8fa5-b34107291176'}, {'type': 'stream', 'value': [{'type': 'page', 'value': 3, 'id': '8c0d7de7-4f77-4477-be67-7d990d0bfb82'}], 'id': '21ffe52a-c0fc-4ecc-92f1-17b356c9cc94'}, {'type': 'list_of_pages', 'value': [5], 'id': '17b972cb-a952-4940-87e2-e4eb00703997'}])
 
+    def test_import_page_with_document_chooser_block(self):
+        data = """{
+                "ids_for_import": [
+                    ["wagtailcore.page", 6]
+                ],
+                "mappings": [
+                    ["wagtailcore.page", 6, "0c7a9390-16cb-11ea-8000-0800278dc04d"],
+                    ["wagtailcore.page", 300, "33333333-3333-3333-3333-333333333333"],
+                    ["wagtaildocs.document", 1, "ffffffff-ffff-ffff-ffff-ffffffffffff"]
+                ],
+                "objects": [
+                    {
+                        "model": "tests.pagewithstreamfield",
+                        "pk": 6,
+                        "fields": {
+                            "title": "I have a streamfield",
+                            "slug": "i-have-a-streamfield",
+                            "live": true,
+                            "seo_title": "",
+                            "show_in_menus": false,
+                            "wagtail_admin_comments": [],
+                            "search_description": "",
+                            "body": "[{\\"type\\": \\"document\\", \\"value\\": 1, \\"id\\": \\"17b972cb-a952-4940-87e2-e4eb00703997\\"}]"
+                        },
+                        "parent_id": 300
+                    }
+                ]
+        }"""
+        importer = ImportPlanner(root_page_source_pk=1, destination_parent_id=None)
+        importer.add_json(data)
+        importer.run()
+        page = PageWithStreamField.objects.get(slug="i-have-a-streamfield")
+
+        imported_streamfield = page.body.stream_block.get_prep_value(page.body)
+
+        # Check that DocumentChooserBlock ids are converted correctly to those on the destination site
+        self.assertEqual(
+            imported_streamfield,
+            [
+                {
+                    'id': '17b972cb-a952-4940-87e2-e4eb00703997',
+                    'type': 'document',
+                    'value': 1,
+                },
+            ],
+        )
+
     def test_import_page_with_streamfield_page_links_where_linked_pages_not_imported(self):
         data = """{
                 "ids_for_import": [

--- a/wagtail_transfer/streamfield.py
+++ b/wagtail_transfer/streamfield.py
@@ -163,11 +163,11 @@ class RichTextBlockHandler(BaseBlockHandler):
 class ChooserBlockHandler(BaseBlockHandler):
     def get_object_references(self, value):
         if value:
-            return {(get_base_model(self.block.target_model), value)}
+            return {(get_base_model(self.block.model_class), value)}
         return set()
 
     def update_ids(self, value, destination_ids_by_source):
-        value = destination_ids_by_source.get((get_base_model(self.block.target_model), value))
+        value = destination_ids_by_source.get((get_base_model(self.block.model_class), value))
         return value
 
 


### PR DESCRIPTION
ChooserBlock.target_model returns a string when we are expecting a model class, resulting in an error. This PR fixes this by using ChooserBlock.model_class instead.