### PR TITLE
Wagtail 5.1

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Unreleased
+~~~~~~~~~~~~~~~~~~
+
+ * Dropped support for Python 3.7 (Nick Moreton, Katherine Domingo)
+ * Wagtail 5.1 update (https://github.com/wagtail/wagtail-transfer/pull/150) (Nick Moreton)
+ * Wagtail 5.0 update (https://github.com/wagtail/wagtail-transfer/pull/148) (Katherine Domingo)
+
 
 0.9.1 (01.03.2023)
 ~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -39,5 +38,6 @@ setup(
         'Framework :: Django',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 4',
+        'Framework :: Wagtail :: 5',
     ],
 )

--- a/wagtail_transfer/static_src/chooser/PageChooserResult.js
+++ b/wagtail_transfer/static_src/chooser/PageChooserResult.js
@@ -99,7 +99,7 @@ class PageChooserResult extends React.Component {
           href={page.meta.html_url}
           target="_blank"
           rel="noopener noreferrer"
-          className="status-tag primary"
+          className="w-status w-status--primary"
         >
           {page.meta.status.status}
         </a>

--- a/wagtail_transfer/vendor/wagtail_admin_api/views.py
+++ b/wagtail_transfer/vendor/wagtail_admin_api/views.py
@@ -102,6 +102,8 @@ class PagesForExplorerAdminAPIViewSet(PagesAdminAPIViewSet):
     ]
 
     def get_root_page(self):
+        if WAGTAIL_VERSION >= (5, 1):
+            return PagePermissionPolicy().explorable_root_instance(self.request.user)
         return get_explorable_root_page(self.request.user)
 
     def get_base_queryset(self, models=None):


### PR DESCRIPTION
Includes this PR: https://github.com/wagtail/wagtail-transfer/pull/148

[Wagtail 5.1 release notes](https://docs.wagtail.org/en/stable/releases/5.1.html)

Upgrade considerations:
- [get_pages_with_direct_explore_permission, get_explorable_root_page, and users_with_page_permission are deprecated](https://docs.wagtail.org/en/stable/releases/5.1.html#get-pages-with-direct-explore-permission-get-explorable-root-page-and-users-with-page-permission-are-deprecated)
- [UserPagePermissionsProxy is deprecated](https://docs.wagtail.org/en/stable/releases/5.1.html#userpagepermissionsproxy-is-deprecated)