### PR TITLE
Remove Wagtail 4.2 from CI matrix, add 5.{0,1}

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,9 +46,12 @@ workflows:
     jobs:
       - build-and-test:
           wagtail-version: "wagtail>=4.1,<4.2"
-          python-version: "3.7"
+          python-version: "3.8"
       - build-and-test:
-          wagtail-version: "wagtail>=4.2,<4.3"
+          wagtail-version: "wagtail>=5.0,<5.1"
+          python-version: "3.11"
+      - build-and-test:
+          wagtail-version: "wagtail>=5.1,<5.2"
           python-version: "3.11"
   nightly:
     jobs:


### PR DESCRIPTION
Complements https://github.com/wagtail/wagtail-transfer/pull/150

Wagtail 4.2 is unsupported, so remove it from the CircleCI matrix. Add 5.0 and 5.1.