### PR TITLE
Handle rich text link handler raising NotImplementedError

### DIFF
--- a/tests/tests/test_api.py
+++ b/tests/tests/test_api.py
@@ -300,6 +300,49 @@ class TestPagesApi(TestCase):
             for model, pk, uid in data['mappings']
         ))
 
+    def test_rich_text_field_with_unhandled_link_type(self):
+        """
+        Rich text fields with custom link handlers are handled gracefully.
+
+        If rich text includes custom link/embed types that do not implement
+        `get_model', the import shouldn't fail.
+        """
+        body = 'Hello <a id="42" linktype="custom-link">world</a>'
+        page = PageWithRichText(
+            title="Rich text with unhandled link type",
+            body=body,
+        )
+
+        parent_page = Page.objects.get(url_path='/home/existing-child-page/')
+        parent_page.add_child(instance=page)
+
+        response = self.get(page.id)
+        data = response.json()
+        self.assertEqual(data["objects"][0]["fields"]["body"], body)
+
+    def test_rich_text_block_with_unhandled_link_type(self):
+        """
+        Rich text blocks with custom link handlers are handled gracefully.
+        """
+        body = [
+            {
+                "type": "rich_text",
+                "value": 'Hello <a id="42" linktype="custom-link">world</a>',
+            },
+        ]
+        page = PageWithStreamField(
+            title="Rich text with unhandled link type",
+            body=body,
+        )
+
+        parent_page = Page.objects.get(url_path='/home/existing-child-page/')
+        parent_page.add_child(instance=page)
+
+        response = self.get(page.id)
+        data = response.json()
+        stream_field_data = json.loads(data["objects"][0]["fields"]["body"])
+        self.assertEqual(stream_field_data[0]["value"], body[0]["value"])
+
     def test_streamfield_with_page_links_in_new_listblock_format(self):
         page = PageWithStreamField(title="I have a streamfield",
                                    body=json.dumps([

--- a/tests/tests/test_import.py
+++ b/tests/tests/test_import.py
@@ -534,6 +534,85 @@ class TestImport(TestCase):
 
         # TODO: this should include an embed type as well once document/image import is added
 
+    def test_import_page_with_unhandled_rich_text_feature(self):
+        """
+        Rich text fields with custom link handlers should be gracefully.
+
+        If rich text includes custom link/embed types that do not implement
+        `get_model', the import shouldn't fail.
+        """
+
+        data = """{
+            "ids_for_import": [
+                ["wagtailcore.page", 15]
+            ],
+            "mappings": [
+                ["wagtailcore.page", 12, "11111111-1111-1111-1111-111111111111"],
+                ["wagtailcore.page", 15, "01010101-0005-8765-7889-987889889898"]
+            ],
+            "objects": [
+                {
+                    "model": "tests.pagewithrichtext",
+                    "pk": 15,
+                    "parent_id": 12,
+                    "fields": {
+                        "title": "Imported page with rich text",
+                        "show_in_menus": false,
+                        "live": true,
+                        "slug": "imported-rich-text-page",
+                        "body": "Hello <a id=\\"42\\" linktype=\\"custom-link\\">world</a>",
+                        "wagtail_admin_comments": []
+                    }
+                }
+            ]
+        }"""
+
+        importer = ImportPlanner(root_page_source_pk=1, destination_parent_id=None)
+        importer.add_json(data)
+        importer.run()
+
+        page = PageWithRichText.objects.get(slug="imported-rich-text-page")
+
+        # tests that the custom linktype is imported successfully
+        self.assertEqual(page.body, 'Hello <a id="42" linktype="custom-link">world</a>')
+
+    def test_import_page_with_unhandled_rich_text_feature_stream_field(self):
+        """
+        Rich text blocks with custom link handlers should be gracefully.
+        """
+
+        data = """{
+            "ids_for_import": [["wagtailcore.page", 6]],
+            "mappings": [
+                ["wagtailcore.page", 6, "0c7a9390-16cb-11ea-8000-0800278dc04d"],
+                ["wagtailcore.page", 300, "33333333-3333-3333-3333-333333333333"]
+            ],
+            "objects": [
+                {
+                    "model": "tests.pagewithstreamfield",
+                    "pk": 6,
+                    "parent_id": 300,
+                    "fields": {
+                        "title": "Imported page with rich text",
+                        "show_in_menus": false,
+                        "live": true,
+                        "slug": "imported-rich-text-page",
+                        "body": "[{\\"type\\": \\"rich_text\\", \\"value\\": \\"Hello <a id=\\\\\\"42\\\\\\" linktype=\\\\\\"custom-link\\\\\\">world</a>\\", \\"id\\": \\"fc3b0d3d-d316-4271-9e31-84919558188a\\"}]",
+                        "wagtail_admin_comments": []
+                    }
+                }
+            ]
+        }"""
+
+        importer = ImportPlanner(root_page_source_pk=1, destination_parent_id=None)
+        importer.add_json(data)
+        importer.run()
+
+        page = PageWithStreamField.objects.get(slug="imported-rich-text-page")
+
+        # tests that the custom linktype is imported successfully
+        self.assertEqual(page.body[0].value.source, 'Hello <a id="42" linktype="custom-link">world</a>')
+
     def test_import_page_with_null_rich_text(self):
         data = """{
             "ids_for_import": [

--- a/tests/wagtail_hooks.py
+++ b/tests/wagtail_hooks.py
@@ -10,13 +10,33 @@ class CustomLinkHandler(LinkHandler):
     the `get_model' method, which we call when processing links - this class
     implements that pattern.
     """
-    identifier = "custom-link"
+
+    identifier = "custom-link-notimplemented"
 
     @classmethod
     def expand_db_attributes(cls, _):
-        return '<a href="https://http.cat">'
+        return '<a href="https://notimplemented.com">'
+
+
+class CustomLinkHandlerNoneModel(LinkHandler):
+    """
+    Custom link handler to test transfer of rich text with custom link types.
+
+    Used for testing the case that the `get_model' method returns None.
+    """
+
+    identifier = "custom-link-none"
+
+    @staticmethod
+    def get_model():
+        return None
+
+    @classmethod
+    def expand_db_attributes(cls, _):
+        return '<a href="https://none.com">'
 
 
 @hooks.register("register_rich_text_features")
-def register_custom_link(features):
+def register_custom_links(features):
     features.register_link_type(CustomLinkHandler)
+    features.register_link_type(CustomLinkHandlerNoneModel)

--- a/tests/wagtail_hooks.py
+++ b/tests/wagtail_hooks.py
@@ -1,0 +1,22 @@
+from wagtail import hooks
+from wagtail.rich_text import LinkHandler
+
+
+class CustomLinkHandler(LinkHandler):
+    """
+    Custom link handler to test transfer of rich text with custom link types.
+
+    There are situations where a `LinkHandler' subclass might not implement
+    the `get_model' method, which we call when processing links - this class
+    implements that pattern.
+    """
+    identifier = "custom-link"
+
+    @classmethod
+    def expand_db_attributes(cls, _):
+        return '<a href="https://http.cat">'
+
+
+@hooks.register("register_rich_text_features")
+def register_custom_link(features):
+    features.register_link_type(CustomLinkHandler)

--- a/wagtail_transfer/richtext.py
+++ b/wagtail_transfer/richtext.py
@@ -46,7 +46,7 @@ class RichTextReferenceHandler:
             tag_body_offset = match.start(0)
             new_tag_string = match.group(0)[:(match.start(1)-tag_body_offset)] + new_tag_body + match.group(0)[(match.end(1)-tag_body_offset):]
             return new_tag_string
-        except KeyError:
+        except (KeyError, NotImplementedError):
             # If the relevant handler cannot be found, don't update the tag id
             pass
         return match.group(0)
@@ -60,9 +60,10 @@ class RichTextReferenceHandler:
                 try:
                     handler = self.handlers[attrs[self.type_attribute]]
                     objects.add((get_base_model(handler.get_model()), int(attrs['id'])))
-                except KeyError:
+                except (KeyError, NotImplementedError):
                     # If no handler can be found, no object reference can be added.
-                    # This might occur when the link is a plain url
+                    # This might occur when the link is a plain url, or a custom link
+                    # or embed type.
                     pass
         return objects
 


### PR DESCRIPTION
When using `wagtail-transfer` to transfer models that contain rich text with custom entities (e.g. those provided by [wagtail-shortcode](https://github.com/Morsey187/wagtail-shortcode)), transfers can fail with a `NotImplementedError`. This is due to `transfer` calling `get_model` on the entity's registered handler. This PR catches the `NotImplementedError`, so that a transfer won't fail entirely in this case.

This does however mean that objects referenced through these custom entities may not be imported to the destination instance, and the references in the rich text won't be updated to point to the objects on the destination. The potential consequences of this are incorrect or missing data on the destination site.

We could ask users of `wagtail-shortcode` to implement `get_model` on their link handler subclass, but that doesn't work in the case of entities that don't have an `id` attribute - a shortcode might identify a related object by its slug, for example - and `wagtail-transfer` both retrieves and caches/tracks objects by `id`. A proper fix for this will require some deeper thought.

I investigated how Wagtail's reference index extracts references from rich text, but changing `wagtail-transfer` to use this functionality wouldn't meet the requirement of _rewriting_ references in rich text.