### PR TITLE
Don't convert app labels in config model IDs to lowercase

### DIFF
--- a/wagtail_transfer/field_adapters.py
+++ b/wagtail_transfer/field_adapters.py
@@ -20,7 +20,7 @@ from wagtail.fields import RichTextField, StreamField
 
 from .files import File, FileTransferError, get_file_hash, get_file_size
 from .locators import get_locator_for_model
-from .models import get_base_model, get_base_model_for_path
+from .models import get_base_model, get_base_model_for_path, normalize_model_label
 from .richtext import get_reference_handler
 from .streamfield import get_object_references, update_object_ids
 
@@ -29,10 +29,10 @@ logger = logging.getLogger(__name__)
 
 WAGTAILTRANSFER_FOLLOWED_REVERSE_RELATIONS = getattr(settings, "WAGTAILTRANSFER_FOLLOWED_REVERSE_RELATIONS", [('wagtailimages.image', 'tagged_items', True)])
 FOLLOWED_REVERSE_RELATIONS = {
-    (model_label.lower(), relation.lower()) for model_label, relation, _ in WAGTAILTRANSFER_FOLLOWED_REVERSE_RELATIONS
+    (normalize_model_label(model_label), relation.lower()) for model_label, relation, _ in WAGTAILTRANSFER_FOLLOWED_REVERSE_RELATIONS
 }
 DELETED_REVERSE_RELATIONS = {
-    (model_label.lower(), relation.lower()) for model_label, relation, track_deletions in WAGTAILTRANSFER_FOLLOWED_REVERSE_RELATIONS if track_deletions
+    (normalize_model_label(model_label), relation.lower()) for model_label, relation, track_deletions in WAGTAILTRANSFER_FOLLOWED_REVERSE_RELATIONS if track_deletions
 }
 ADMIN_BASE_URL = getattr(
     settings, "WAGTAILADMIN_BASE_URL",

--- a/wagtail_transfer/locators.py
+++ b/wagtail_transfer/locators.py
@@ -12,7 +12,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured
 from django.db import IntegrityError
 
-from .models import IDMapping, get_base_model
+from .models import IDMapping, get_base_model, normalize_model_label
 
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ LOOKUP_FIELDS = {
     'contenttypes.contenttype': ['app_label', 'model'],
 }
 for model_label, fields in getattr(settings, 'WAGTAILTRANSFER_LOOKUP_FIELDS', {}).items():
-    LOOKUP_FIELDS[model_label.lower()] = fields
+    LOOKUP_FIELDS[normalize_model_label(model_label)] = fields
 
 
 class IDMappingLocator:

--- a/wagtail_transfer/models.py
+++ b/wagtail_transfer/models.py
@@ -45,3 +45,9 @@ def get_base_model_for_path(model_path):
     (e.g. for 'blog.blog_page', return Page)
     """
     return get_base_model(get_model_for_path(model_path))
+
+
+def normalize_model_label(label):
+    app_label, model_name = label.rsplit('.', 1)
+    return "{}.{}".format(app_label, model_name.lower())
+    

--- a/wagtail_transfer/operations.py
+++ b/wagtail_transfer/operations.py
@@ -13,7 +13,7 @@ from wagtail.models import Page
 
 from .field_adapters import adapter_registry
 from .locators import get_locator_for_model
-from .models import get_base_model, get_base_model_for_path, get_model_for_path
+from .models import get_base_model, get_base_model_for_path, get_model_for_path, normalize_model_label
 
 
 logger = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 default_update_related_models = ['wagtailimages.image']
 
 UPDATE_RELATED_MODELS = [
-    model_label.lower()
+    normalize_model_label(model_label)
     for model_label in getattr(settings, 'WAGTAILTRANSFER_UPDATE_RELATED_MODELS', default_update_related_models)
 ]
 
@@ -31,7 +31,7 @@ UPDATE_RELATED_MODELS = [
 default_no_follow_models = ['wagtailcore.page', 'contenttypes.contenttype']
 
 NO_FOLLOW_MODELS = [
-    model_label.lower()
+    normalize_model_label(model_label)
     for model_label in getattr(settings, 'WAGTAILTRANSFER_NO_FOLLOW_MODELS', default_no_follow_models)
 ]
 


### PR DESCRIPTION
Although rare and not recommended, non-lowercase app labels do in fact exist, so support them the same way Django does.
(E.g. model._meta.label_lower doesn't lowercase the app label, neither does the app registry).

Fixes #161 