### PR TITLE
Specify Python 3.12 for running nightly tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,13 @@ jobs:
           name: Test
 
   nightly-wagtail-test:
-    executor: python/default
+    parameters:
+      python-version:
+        default: "3.12"
+        type: string
+    executor:
+      name: python/default
+      tag: "<< parameters.python-version >>"
     steps:
       - checkout
       - run: git clone git@github.com:wagtail/wagtail.git


### PR DESCRIPTION
As per https://circleci.com/developer/orbs/orb/circleci/python#executors, the default tag is currently 3.8, which is no longer supported by Wagtail main.