### PR TITLE
Wagtail 7.2 maintenance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
         default: "django"
         type: string
       python-version:
-        default: "3.13"
+        default: "3.14"
         type: string
     executor:
       name: python/default
@@ -58,13 +58,13 @@ workflows:
           django-version: "django>=4.2,<4.3"
           python-version: "3.9"
       - build-and-test:
-          wagtail-version: "wagtail>=7.0,<7.1"
-          django-version: "django>=5.1,<5.2"
-          python-version: "3.12"
-      - build-and-test:
           wagtail-version: "wagtail>=7.1,<7.2"
           django-version: "django>=5.2,<5.3"
           python-version: "3.13"
+      - build-and-test:
+          wagtail-version: "wagtail>=7.2,<7.3"
+          django-version: "django>=5.2,<5.3"
+          python-version: "3.14"
   nightly:
     jobs:
       - nightly-wagtail-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,10 +56,10 @@ workflows:
       - build-and-test:
           wagtail-version: "wagtail>=6.3,<6.4"
           django-version: "django>=4.2,<4.3"
-          python-version: "3.9"
+          python-version: "3.10"
       - build-and-test:
-          wagtail-version: "wagtail>=7.1,<7.2"
-          django-version: "django>=5.2,<5.3"
+          wagtail-version: "wagtail>=7.0,<7.1"
+          django-version: "django>=5.1,<5.2"
           python-version: "3.13"
       - build-and-test:
           wagtail-version: "wagtail>=7.2,<7.3"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages=find_packages(exclude=('tests',)),
     include_package_data=True,
     install_requires=[
-        'wagtail>=5.2'
+        'wagtail>=6.3'
     ],
     extras_require={
         'docs': [
@@ -31,11 +31,11 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.1',


### PR DESCRIPTION
This pull request updates the project's dependencies and configuration to support newer versions of Wagtail and Python. The main changes ensure compatibility with Wagtail 6.3+ and add Python 3.14

**Dependency and compatibility updates:**

* Updated the minimum required Wagtail version in `setup.py` to `wagtail>=6.3`.
* Added Python 3.14 to the supported versions in the `setup.py` classifiers.

**Continuous Integration (CI) configuration:**

* Changed the default Python version for jobs in `.circleci/config.yml` from 3.13 to 3.14.
* Updated the build-and-test matrix in `.circleci/config.yml` to add a job for Wagtail 7.2 and Python 3.14, and removed the job for Wagtail 7.1