### PR TITLE
Add slug validation before page import to prevent ValidationError

### DIFF
--- a/tests/tests/test_views.py
+++ b/tests/tests/test_views.py
@@ -2,6 +2,7 @@ import json
 from datetime import date, datetime, timezone
 from unittest import mock
 
+from django.contrib import messages
 from django.contrib.auth.models import AnonymousUser, Group, Permission, User
 from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import redirect
@@ -293,6 +294,82 @@ class TestImportView(TestCase):
         snippet = content['items'][0]
         self.assertEqual(snippet['model_label'], 'tests.category')
         self.assertEqual(snippet['name'], 'Category')
+    
+    def test_slug_validation_create_page(self, get, post):
+        get.return_value.status_code = 200
+        get.return_value.content = b"""{
+            "ids_for_import": [
+                ["wagtailcore.page", 20]
+            ],
+            "mappings": [
+                ["wagtailcore.page", 20, "20202020-2020-2020-2020-202020202020"]
+            ],
+            "objects": [
+                {
+                    "model": "tests.sponsoredpage",
+                    "pk": 20,
+                    "parent_id": 2,
+                    "fields": {
+                        "title": "Same slug new page",
+                        "show_in_menus": false,
+                        "live": true,
+                        "slug": "existing-child-page",
+                        "intro": "This new page with slug that already exist at destination",
+                        "wagtail_admin_comments": []
+                    }
+                }
+            ]
+        }"""
+
+        response = self.client.post("/admin/wagtail-transfer/import/", {
+            "source": "staging",
+            "source_page_id": "20",
+            "dest_page_id": "2",
+        })
+        self.assertRedirects(response, "/admin/wagtail-transfer/choose/")
+        messages_list = list(messages.get_messages(response.wsgi_request))
+        self.assertEqual(len(messages_list), 1)
+        self.assertEqual(messages_list[0].message, "The slug 'existing-child-page' is already in use at the selected parent page. Make sure the slug is unique and try again.")
+        self.assertEqual(messages_list[0].level, messages.ERROR)
+
+    def test_slug_validation_update_page(self, get, post):
+        get.return_value.status_code = 200
+        get.return_value.content = b"""{
+            "ids_for_import": [
+                ["wagtailcore.page", 23]
+            ],
+            "mappings": [
+                ["wagtailcore.page", 23, "00017017-5555-5555-5555-555555555555"]
+            ],
+            "objects": [
+                {
+                    "model": "tests.sponsoredpage",
+                    "pk": 23,
+                    "parent_id": 2,
+                    "fields": {
+                        "title": "Same slug page to be updated",
+                        "show_in_menus": false,
+                        "live": true,
+                        "slug": "existing-child-page",
+                        "intro": "This page to be updated with slug that already exist at destination",
+                        "wagtail_admin_comments": []
+                    }
+                }
+            ]
+        }"""
+
+        response = self.client.post("/admin/wagtail-transfer/import/", {
+            "source": "staging",
+            "source_page_id": "23",
+            "dest_page_id": "",
+        })
+        self.assertRedirects(response, "/admin/wagtail-transfer/choose/")
+        messages_list = list(messages.get_messages(response.wsgi_request))
+        self.assertEqual(len(messages_list), 1)
+        self.assertEqual(messages_list[0].message, "The slug 'existing-child-page' is already in use at the selected parent page. Make sure the slug is unique and try again.")
+        self.assertEqual(messages_list[0].level, messages.ERROR)
+        page = SponsoredPage.objects.get(id=5)
+        self.assertEqual(page.slug, "oil-is-great")
 
 
 class ImportPermissionsTests(TestCase):

--- a/wagtail_transfer/views.py
+++ b/wagtail_transfer/views.py
@@ -252,6 +252,27 @@ def import_missing_object_data(source, importer: ImportPlanner):
     return importer
 
 
+def is_slug_available(request, json_data):
+    data = json.loads(json_data)
+    source_page_id = int(request.POST["source_page_id"])
+    dest_page_id = request.POST["dest_page_id"] or None
+
+    slug = next((item["fields"].get("slug") for item in data["objects"] if issubclass(get_model_for_path(item["model"]), Page) and item["pk"] == source_page_id), "")
+    error_msg = f"The slug '{slug}' is already in use at the selected parent page. Make sure the slug is unique and try again."
+
+    if dest_page_id:
+        parent_page = Page.objects.filter(id=dest_page_id).first()
+        page = None
+    else:
+        uid = next((item[2] for item in data["mappings"] if item[0] == "wagtailcore.page" and item[1] == source_page_id), "")
+        page = get_locator_for_model(Page).find(uid)
+        parent_page = page.get_parent() if page else None
+    
+    if parent_page and slug:
+        return Page._slug_is_available(slug, parent_page, page), error_msg
+    return True, error_msg
+
+
 def import_page(request):
     source = request.POST['source']
     base_url = settings.WAGTAILTRANSFER_SOURCES[source]['BASE_URL']
@@ -262,6 +283,11 @@ def import_page(request):
         auth=requests_auth(source),
         params={'digest': digest}
     )
+
+    slug_available, slug_error_msg = is_slug_available(request, response.content)
+    if not slug_available:
+        messages.add_message(request, messages.ERROR, slug_error_msg)
+        return redirect("wagtail_transfer_admin:choose_page")
 
     dest_page_id = request.POST['dest_page_id'] or None
     importer = ImportPlanner.for_page(source=request.POST['source_page_id'], destination=dest_page_id, source_site=source)


### PR DESCRIPTION
# Summary

This PR adds slug availability validation before initiating the page import process, preventing unhandled `ValidationError` exceptions when the root imported page has a slug that conflicts with existing pages on the destination site.

# Changes

- Added slug validation using Wagtail's `_slug_is_available` method before starting the import process
- Display error message on the import form when slug conflicts are detected
- Prevent application crashes by catching slug conflicts early in the import workflow

Fixes #192 